### PR TITLE
Implement canonical public Schelling Game

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,49 @@
       "license": "ISC",
       "dependencies": {
         "better-sqlite3": "^12.8.0",
+        "ethers": "^6.16.0",
         "express": "^5.2.1",
         "uuid": "^13.0.0",
         "ws": "^8.19.0"
+      }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+      "license": "MIT"
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
       }
     },
     "node_modules/accepts": {
@@ -27,6 +67,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "license": "MIT"
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -354,6 +400,55 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/ethers": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.16.0.tgz",
+      "integrity": "sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.17.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ethers/node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/expand-template": {
@@ -1201,6 +1296,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD"
+    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -1226,6 +1327,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "homepage": "https://github.com/proveuswrong/schelling-game#readme",
   "dependencies": {
     "better-sqlite3": "^12.8.0",
+    "ethers": "^6.16.0",
     "express": "^5.2.1",
     "uuid": "^13.0.0",
     "ws": "^8.19.0"

--- a/public/index.html
+++ b/public/index.html
@@ -4,8 +4,9 @@
 <meta charset="UTF-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <title>Schelling Game</title>
+<script src="https://cdn.jsdelivr.net/npm/ethers@6/dist/ethers.umd.min.js"></script>
 <style>
-/* ── Reset & base ──────────────────────────────────────────────────── */
+/* ── Reset & tokens ─────────────────────────────────────────────── */
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 :root{
   --bg:#0f0f0f;--surface:#1a1a1a;--surface2:#242424;--border:#2e2e2e;
@@ -14,235 +15,222 @@
   --radius:8px;--font:'Segoe UI',system-ui,sans-serif;
 }
 html,body{height:100%;background:var(--bg);color:var(--text);font-family:var(--font);font-size:15px;line-height:1.5}
-a{color:var(--accent);text-decoration:none}a:hover{text-decoration:underline}
 button{cursor:pointer;border:none;border-radius:var(--radius);padding:.5rem 1.1rem;font-size:.9rem;font-family:inherit;transition:background .15s,transform .1s}
 button:active{transform:scale(.97)}
-.btn-primary{background:var(--accent);color:#fff}
-.btn-primary:hover{background:var(--accent2)}
+button:disabled{opacity:.4;cursor:default;transform:none}
+.btn-primary{background:var(--accent);color:#fff}.btn-primary:hover:not(:disabled){background:var(--accent2)}
 .btn-danger{background:var(--red);color:#fff}
 .btn-ghost{background:transparent;border:1px solid var(--border);color:var(--text)}
-.btn-ghost:hover{border-color:var(--accent);color:var(--accent)}
-input,select{background:var(--surface2);border:1px solid var(--border);border-radius:var(--radius);color:var(--text);font-family:inherit;font-size:.95rem;padding:.5rem .75rem;width:100%;outline:none;transition:border-color .15s}
-input:focus,select:focus{border-color:var(--accent)}
+.btn-ghost:hover:not(:disabled){border-color:var(--accent);color:var(--accent)}
+input{background:var(--surface2);border:1px solid var(--border);border-radius:var(--radius);color:var(--text);font-family:inherit;font-size:.95rem;padding:.5rem .75rem;width:100%;outline:none;transition:border-color .15s}
+input:focus{border-color:var(--accent)}
 label{font-size:.85rem;color:var(--muted);display:block;margin-bottom:.3rem}
 .card{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:1.25rem}
 .hidden{display:none!important}
-/* ── Layout ─────────────────────────────────────────────────────────── */
+/* ── Layout ─────────────────────────────────────────────────────── */
 #app{max-width:900px;margin:0 auto;padding:1rem}
-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:1.5rem;border-bottom:1px solid var(--border);padding-bottom:.75rem}
+header{display:flex;align-items:center;justify-content:space-between;margin-bottom:1.5rem;border-bottom:1px solid var(--border);padding-bottom:.75rem;flex-wrap:wrap;gap:.5rem}
 header h1{font-size:1.4rem;letter-spacing:.05em;color:var(--accent)}
-/* ── Views ───────────────────────────────────────────────────────── */
-.view:not(.active){display:none!important}
-/* Lobby */
-#lobby-form{display:grid;gap:.75rem;max-width:420px;margin:0 auto}
-#lobby-form .row{display:grid;grid-template-columns:1fr 1fr;gap:.75rem}
-#room-code-display{font-size:2rem;font-weight:700;letter-spacing:.15em;color:var(--accent);text-align:center;padding:.5rem;background:var(--surface2);border-radius:var(--radius);border:1px solid var(--border)}
-.player-list{display:flex;flex-wrap:wrap;gap:.5rem;margin-top:.5rem}
-.player-chip{background:var(--surface2);border:1px solid var(--border);border-radius:50px;padding:.2rem .75rem;font-size:.85rem;display:flex;align-items:center;gap:.35rem}
-.player-chip.host::after{content:'👑';font-size:.75rem}
-.player-chip.disconnected{opacity:.5}
-/* Game view */
-#game-view{display:grid;grid-template-columns:1fr 280px;gap:1rem}
-@media(max-width:650px){#game-view{grid-template-columns:1fr}}
-#game-main{display:flex;flex-direction:column;gap:.75rem}
+#header-profile{display:flex;align-items:center;gap:.75rem;font-size:.85rem;color:var(--muted)}
+#header-profile .name{color:var(--text);font-weight:600}
+#header-profile .bal{color:var(--accent)}
+nav{display:flex;gap:.5rem}
+/* ── Views ──────────────────────────────────────────────────────── */
+.view{display:none}.view.active{display:block}
+/* Auth */
+#auth-view{max-width:420px;margin:2rem auto;text-align:center}
+#auth-view h2{margin-bottom:1rem}
+#auth-view .card{display:flex;flex-direction:column;gap:.75rem;align-items:stretch}
+#auth-status{font-size:.85rem;color:var(--muted);min-height:1.5em}
+#name-section{display:flex;flex-direction:column;gap:.5rem}
+#name-section .row{display:flex;gap:.5rem}
+#name-section input{flex:1}
+/* Queue */
+#queue-view .card{max-width:520px;margin:0 auto}
+#queue-players{list-style:none;display:flex;flex-wrap:wrap;gap:.5rem;margin:.75rem 0}
+#queue-players li{background:var(--surface2);border:1px solid var(--border);border-radius:50px;padding:.2rem .75rem;font-size:.85rem}
+#forming-banner{background:rgba(255,152,0,.1);border:1px solid var(--orange);border-radius:var(--radius);padding:.6rem 1rem;font-size:.9rem;color:var(--orange);text-align:center;margin-top:.75rem}
+.toggle-row{display:flex;align-items:center;gap:.5rem;font-size:.85rem;color:var(--muted);margin-top:.75rem}
+.toggle-row input[type=checkbox]{width:auto;accent-color:var(--accent)}
+/* Play */
+#play-view.active{display:grid;grid-template-columns:1fr 280px;gap:1rem}
+@media(max-width:650px){#play-view{grid-template-columns:1fr}}
+#play-main{display:flex;flex-direction:column;gap:.75rem}
 /* Timer */
-#timer-wrap{display:flex;align-items:center;gap:.75rem;font-size:.9rem;color:var(--muted)}
-#timer-bar-outer{flex:1;height:6px;background:var(--border);border-radius:3px;overflow:hidden}
-#timer-bar{height:100%;background:var(--accent);transition:width .5s linear,background .3s}
-#timer-num{font-weight:700;min-width:2.5rem;text-align:right;transition:color .3s}
-#timer-num.pulse{animation:pulse .5s infinite alternate}
+.timer-wrap{display:flex;align-items:center;gap:.75rem;font-size:.9rem;color:var(--muted)}
+.timer-bar-outer{flex:1;height:6px;background:var(--border);border-radius:3px;overflow:hidden}
+.timer-bar{height:100%;background:var(--accent);transition:width .25s linear,background .3s}
+.timer-num{font-weight:700;min-width:2.5rem;text-align:right}
+.timer-num.urgent{color:var(--red);animation:pulse .5s infinite alternate}
 @keyframes pulse{to{opacity:.3}}
 /* Question */
 #question-card{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:1.25rem}
 #phase-label{font-size:.75rem;text-transform:uppercase;letter-spacing:.08em;margin-bottom:.5rem;color:var(--muted)}
 #question-text{font-size:1.1rem;font-weight:600;margin-bottom:1rem;line-height:1.4}
-/* Slider input */
-#slider-wrap{display:flex;flex-direction:column;gap:.5rem}
-#slider-input{width:100%;accent-color:var(--accent);cursor:pointer;height:6px}
-#slider-value{font-size:1.4rem;font-weight:700;color:var(--accent);text-align:center}
-#slider-labels{display:flex;justify-content:space-between;font-size:.75rem;color:var(--muted)}
-/* Select grid */
-#select-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(130px,1fr));gap:.5rem}
-.opt-card{background:var(--surface2);border:2px solid var(--border);border-radius:var(--radius);padding:.6rem .9rem;cursor:pointer;text-align:center;font-size:.9rem;transition:border-color .15s,background .15s;user-select:none}
-.opt-card:hover{border-color:var(--accent)}
-.opt-card.selected{border-color:var(--accent);background:rgba(74,144,217,.15);color:var(--accent);font-weight:600}
-.opt-card.disabled{opacity:.4;cursor:default}
-/* Commit button */
-#commit-area{display:flex;align-items:center;gap:.75rem;flex-wrap:wrap}
+#select-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(140px,1fr));gap:.5rem}
+.opt-btn{background:var(--surface2);border:2px solid var(--border);border-radius:var(--radius);padding:.6rem .9rem;cursor:pointer;text-align:center;font-size:.9rem;transition:border-color .15s,background .15s;user-select:none}
+.opt-btn:hover:not(.disabled){border-color:var(--accent)}
+.opt-btn.selected{border-color:var(--accent);background:rgba(74,144,217,.15);color:var(--accent);font-weight:600}
+.opt-btn.disabled{opacity:.4;cursor:default;pointer-events:none}
+#commit-area{display:flex;align-items:center;gap:.75rem;flex-wrap:wrap;margin-top:.75rem}
 #commit-btn{flex:1;min-width:140px}
-#commit-status-text{font-size:.85rem;color:var(--muted)}
-/* Phase banner */
-#phase-banner{background:var(--surface2);border:1px solid var(--accent);border-radius:var(--radius);padding:.6rem 1rem;font-size:.9rem;color:var(--accent);text-align:center}
-/* Reveal */
-#reveal-area{display:flex;align-items:center;gap:.75rem;flex-wrap:wrap}
+#commit-status{font-size:.85rem;color:var(--muted)}
+#reveal-area{display:flex;align-items:center;gap:.75rem;flex-wrap:wrap;margin-top:.75rem}
 #reveal-btn{flex:1;min-width:140px}
+#reveal-status{font-size:.85rem;color:var(--muted)}
+/* Round result overlay */
+#round-result-banner{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:1rem;margin-top:.75rem}
+#round-result-banner h3{font-size:.95rem;margin-bottom:.6rem;color:var(--muted);text-transform:uppercase;letter-spacing:.06em}
+#result-table{width:100%;border-collapse:collapse;font-size:.85rem}
+#result-table th,#result-table td{padding:.35rem .5rem;text-align:left;border-bottom:1px solid var(--border)}
+#result-table th{color:var(--muted);font-weight:600;font-size:.75rem;text-transform:uppercase}
+#result-table tr:last-child td{border-bottom:none}
+.won-yes{color:var(--green);font-weight:600}
+.won-no{color:var(--red)}
+.credit-yes{color:var(--yellow);font-weight:600}
+.delta-pos{color:var(--green);font-weight:700}
+.delta-neg{color:var(--red);font-weight:700}
+.delta-zero{color:var(--muted)}
 /* Sidebar */
-#game-sidebar{display:flex;flex-direction:column;gap:.75rem}
-/* Players panel */
+#play-sidebar{display:flex;flex-direction:column;gap:.75rem}
 #players-panel{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:1rem}
 #players-panel h3{font-size:.85rem;text-transform:uppercase;letter-spacing:.07em;color:var(--muted);margin-bottom:.6rem}
 .player-row{display:flex;align-items:center;justify-content:space-between;padding:.3rem 0;border-bottom:1px solid var(--border);font-size:.88rem}
 .player-row:last-child{border-bottom:none}
 .player-name{display:flex;align-items:center;gap:.4rem}
-.dot{width:8px;height:8px;border-radius:50%;background:var(--border)}
+.dot{width:8px;height:8px;border-radius:50%;background:var(--border);flex-shrink:0}
 .dot.committed{background:var(--orange)}
 .dot.revealed{background:var(--green)}
+.dot.forfeited{background:var(--red)}
+.dot.disconnected{background:var(--red);animation:pulse 1s infinite alternate}
 .balance-badge{font-size:.8rem;color:var(--muted)}
 /* Chat */
 #chat-panel{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:1rem;display:flex;flex-direction:column;gap:.5rem;max-height:260px}
 #chat-panel h3{font-size:.85rem;text-transform:uppercase;letter-spacing:.07em;color:var(--muted)}
-#chat-messages{flex:1;overflow-y:auto;display:flex;flex-direction:column;gap:.35rem;min-height:80px;max-height:160px}
+#chat-messages{flex:1;overflow-y:auto;display:flex;flex-direction:column;gap:.35rem;min-height:60px;max-height:160px}
 .chat-msg{font-size:.83rem;line-height:1.4}
 .chat-msg .from{font-weight:600;color:var(--accent);margin-right:.3rem}
-.chat-msg .report-btn{font-size:.7rem;color:var(--red);background:none;border:none;cursor:pointer;padding:0 .3rem;opacity:.6}
-.chat-msg .report-btn:hover{opacity:1}
 #chat-input-row{display:flex;gap:.4rem}
 #chat-input{flex:1;font-size:.85rem}
 #chat-send{padding:.4rem .8rem;font-size:.85rem}
-/* Results view */
-#results-view{display:flex;flex-direction:column;gap:1rem}
-#results-header{display:flex;align-items:center;justify-content:space-between}
-#results-header h2{font-size:1.2rem}
-#results-countdown{font-size:.85rem;color:var(--muted)}
-#dot-plot-wrap{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:1rem}
-#dot-plot-svg{width:100%;overflow:visible}
-#stats-row{display:flex;gap:1rem;flex-wrap:wrap}
-.stat-pill{background:var(--surface2);border:1px solid var(--border);border-radius:50px;padding:.3rem .9rem;font-size:.85rem}
-.stat-pill span{font-weight:700;color:var(--accent)}
-#results-players{display:grid;grid-template-columns:repeat(auto-fill,minmax(180px,1fr));gap:.6rem}
-.result-card{background:var(--surface);border:2px solid var(--border);border-radius:var(--radius);padding:.75rem;font-size:.875rem}
-.result-card.coherent{border-color:var(--green)}
-.result-card.incoherent{border-color:var(--red)}
-.result-card .rname{font-weight:700;margin-bottom:.3rem}
-.result-card .rdelta{font-weight:700}
-.result-card .rdelta.pos{color:var(--green)}
-.result-card .rdelta.neg{color:var(--red)}
-#educational-note{background:var(--surface);border-left:3px solid var(--accent);padding:.75rem 1rem;font-size:.87rem;color:var(--muted);border-radius:0 var(--radius) var(--radius) 0;line-height:1.5}
-#cancel-banner{background:rgba(255,152,0,.1);border:1px solid var(--orange);border-radius:var(--radius);padding:.75rem 1rem;color:var(--orange)}
-/* Summary view */
-#summary-view{display:flex;flex-direction:column;gap:1rem}
+#chat-disabled-note{font-size:.75rem;color:var(--muted);text-align:center;padding:.3rem}
+/* Summary */
+#summary-view .card{max-width:620px;margin:0 auto}
 #summary-table{width:100%;border-collapse:collapse;font-size:.9rem}
 #summary-table th,#summary-table td{padding:.5rem .75rem;text-align:left;border-bottom:1px solid var(--border)}
 #summary-table th{color:var(--muted);font-weight:600;font-size:.8rem;text-transform:uppercase}
 #summary-table tr:last-child td{border-bottom:none}
-.profit-pos{color:var(--green);font-weight:700}
-.profit-neg{color:var(--red);font-weight:700}
 /* Leaderboard */
-#leaderboard-view{display:flex;flex-direction:column;gap:1rem}
+#leaderboard-view .card{overflow-x:auto}
 #lb-table{width:100%;border-collapse:collapse;font-size:.9rem}
-#lb-table th,#lb-table td{padding:.5rem .75rem;text-align:left;border-bottom:1px solid var(--border)}
+#lb-table th,#lb-table td{padding:.5rem .75rem;text-align:left;border-bottom:1px solid var(--border);white-space:nowrap}
 #lb-table th{color:var(--muted);font-weight:600;font-size:.8rem;text-transform:uppercase}
 #lb-table tr:last-child td{border-bottom:none}
 #lb-table tr.me td{background:rgba(74,144,217,.08);color:var(--accent)}
+#my-rank-card{margin-bottom:.75rem;background:rgba(74,144,217,.08);border-color:var(--accent)}
 /* Notifications */
-#notif{position:fixed;top:1rem;right:1rem;display:flex;flex-direction:column;gap:.4rem;z-index:999}
-.notif-item{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:.6rem 1rem;font-size:.85rem;min-width:220px;animation:slideIn .2s ease}
+#notif{position:fixed;top:1rem;right:1rem;display:flex;flex-direction:column;gap:.4rem;z-index:999;pointer-events:none}
+.notif-item{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:.6rem 1rem;font-size:.85rem;min-width:220px;animation:slideIn .2s ease;pointer-events:auto}
 .notif-item.error{border-color:var(--red);color:var(--red)}
 .notif-item.success{border-color:var(--green);color:var(--green)}
+.notif-item.warn{border-color:var(--orange);color:var(--orange)}
 @keyframes slideIn{from{opacity:0;transform:translateX(30px)}to{opacity:1;transform:none}}
-/* Misc */
-.mt1{margin-top:.5rem}.mt2{margin-top:1rem}.flex-row{display:flex;gap:.5rem;align-items:center}
+.mt1{margin-top:.5rem}.mt2{margin-top:1rem}
 </style>
 </head>
 <body>
 <div id="app">
   <header>
-    <h1>⬡ Schelling Game</h1>
-    <div class="flex-row">
-      <button class="btn-ghost" id="nav-leaderboard">Leaderboard</button>
-      <button class="btn-ghost" id="nav-lobby">Lobby</button>
+    <h1>Schelling Game</h1>
+    <div id="header-profile" class="hidden">
+      <span class="name" id="header-name"></span>
+      <span class="bal" id="header-balance"></span>
     </div>
+    <nav>
+      <button class="btn-ghost" id="nav-leaderboard">Leaderboard</button>
+      <button class="btn-ghost" id="nav-queue" class="hidden">Queue</button>
+    </nav>
   </header>
 
-  <!-- ── LOBBY ────────────────────────────────────────────────── -->
-  <div id="lobby-view" class="view active">
-    <div style="max-width:480px;margin:0 auto">
-      <div class="card" id="lobby-form">
-        <h2 style="margin-bottom:.75rem">Join or Create Room</h2>
-        <div>
-          <label>Your Username</label>
-          <input id="input-username" type="text" placeholder="e.g. alice" maxlength="20" autocomplete="off"/>
-        </div>
-        <div>
-          <label>Room Code (leave blank to create new)</label>
-          <input id="input-roomcode" type="text" placeholder="e.g. ABC123" maxlength="6" autocomplete="off" style="text-transform:uppercase"/>
-        </div>
-        <div>
-          <label>Rounds (if creating)</label>
-          <select id="input-rounds">
-            <option value="5">5 rounds</option>
-            <option value="7">7 rounds</option>
-            <option value="10" selected>10 rounds</option>
-          </select>
-        </div>
-        <button class="btn-primary" id="join-btn" style="width:100%">Join / Create Room</button>
-      </div>
-
-      <div id="lobby-room" class="card mt2 hidden">
-        <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:.75rem">
-          <div>
-            <div style="font-size:.8rem;color:var(--muted);margin-bottom:.25rem">Room Code</div>
-            <div id="room-code-display">------</div>
-          </div>
-          <div>
-            <div style="font-size:.8rem;color:var(--muted);margin-bottom:.25rem">Rounds</div>
-            <div style="font-size:1.5rem;font-weight:700;color:var(--accent)" id="lobby-rounds-display">-</div>
-          </div>
-        </div>
-        <div style="font-size:.85rem;color:var(--muted);margin-bottom:.4rem">Players</div>
-        <div id="lobby-players" class="player-list"></div>
-        <div class="mt2">
-          <button class="btn-primary" id="start-btn" style="width:100%;display:none">Start Game</button>
-          <div id="waiting-text" style="text-align:center;color:var(--muted);font-size:.85rem">Waiting for host to start…</div>
+  <!-- ── AUTH ──────────────────────────────────────────────────── -->
+  <div id="auth-view" class="view active">
+    <div class="card">
+      <h2>Connect Wallet</h2>
+      <p id="auth-status">Connect your Ethereum wallet to sign in.</p>
+      <button class="btn-primary" id="connect-wallet-btn">Connect MetaMask</button>
+      <div id="name-section" class="hidden">
+        <label>Claim your display name (1-20 chars, A-Z 0-9 _ -)</label>
+        <div class="row">
+          <input id="name-input" type="text" placeholder="e.g. alice" maxlength="20" autocomplete="off" pattern="^[A-Za-z0-9_-]{1,20}$"/>
+          <button class="btn-primary" id="claim-name-btn">Claim</button>
         </div>
       </div>
     </div>
   </div>
 
-  <!-- ── GAME ─────────────────────────────────────────────────── -->
-  <div id="game-view" class="view">
-    <div id="game-main">
+  <!-- ── QUEUE ─────────────────────────────────────────────────── -->
+  <div id="queue-view" class="view">
+    <div class="card">
+      <h2>Public Queue</h2>
+      <p style="color:var(--muted);font-size:.9rem;margin:.5rem 0">Waiting for players. Matches form automatically with 3, 5, or 7 players.</p>
+      <div style="font-size:.9rem;color:var(--muted)">Players in queue: <strong id="queue-count">0</strong></div>
+      <ul id="queue-players"></ul>
+      <div id="forming-banner" class="hidden">
+        Match forming: <strong id="forming-count">0</strong> players reserved.
+        Fill closes in <strong id="forming-timer">--</strong>s
+      </div>
+      <div style="display:flex;gap:.5rem;margin-top:1rem;flex-wrap:wrap">
+        <button class="btn-primary" id="join-queue-btn">Join Queue</button>
+        <button class="btn-danger hidden" id="leave-queue-btn">Leave Queue</button>
+      </div>
+      <div class="toggle-row">
+        <input type="checkbox" id="auto-requeue-toggle" checked/>
+        <label for="auto-requeue-toggle" style="margin:0">Auto-requeue after match</label>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── PLAY ──────────────────────────────────────────────────── -->
+  <div id="play-view" class="view">
+    <div id="play-main">
       <!-- Timer -->
-      <div id="timer-wrap">
-        <div id="phase-label-timer" style="min-width:3.5rem;font-size:.8rem;text-transform:uppercase;letter-spacing:.06em;color:var(--muted)">Commit</div>
-        <div id="timer-bar-outer"><div id="timer-bar" style="width:100%"></div></div>
-        <div id="timer-num">30</div>
+      <div class="timer-wrap">
+        <div id="phase-timer-label" style="min-width:3.5rem;font-size:.8rem;text-transform:uppercase;letter-spacing:.06em;color:var(--muted)">Commit</div>
+        <div class="timer-bar-outer"><div class="timer-bar" id="timer-bar" style="width:100%"></div></div>
+        <div class="timer-num" id="timer-num">30</div>
       </div>
 
-      <!-- Phase banner -->
-      <div id="phase-banner" class="hidden">Reveal your answer now!</div>
-
-      <!-- Question card -->
+      <!-- Question -->
       <div id="question-card">
-        <div id="phase-label">Round <span id="round-num">1</span> / <span id="total-rounds">10</span> — Commit Phase</div>
-        <div id="question-text">Loading…</div>
-
-        <!-- Slider -->
-        <div id="slider-wrap">
-          <div id="slider-labels"><span>0.00</span><span>0.50</span><span>1.00</span></div>
-          <input id="slider-input" type="range" min="0" max="1" step="0.01" value="0.50"/>
-          <div id="slider-value">0.50</div>
+        <div id="phase-label">Round <span id="round-num">1</span> / 10</div>
+        <div id="question-text">Waiting for round...</div>
+        <div id="select-grid"></div>
+        <div id="commit-area" class="hidden">
+          <button class="btn-primary" id="commit-btn" disabled>Lock In</button>
+          <span id="commit-status"></span>
         </div>
-
-        <!-- Select options -->
-        <div id="select-grid" class="hidden"></div>
-
-        <!-- Commit area -->
-        <div id="commit-area" class="mt1">
-          <button class="btn-primary" id="commit-btn">🔒 Lock In</button>
-          <span id="commit-status-text"></span>
+        <div id="reveal-area" class="hidden">
+          <button class="btn-primary" id="reveal-btn">Reveal</button>
+          <span id="reveal-status"></span>
         </div>
+      </div>
 
-        <!-- Reveal area -->
-        <div id="reveal-area" class="hidden mt1">
-          <button class="btn-primary" id="reveal-btn">👁 Reveal</button>
-          <span id="reveal-status-text" style="font-size:.85rem;color:var(--muted)"></span>
-        </div>
+      <!-- Round result -->
+      <div id="round-result-banner" class="hidden">
+        <h3>Round <span id="result-round-num">?</span> Result</h3>
+        <div id="void-banner" class="hidden" style="color:var(--orange);margin-bottom:.5rem;font-weight:600">Round voided: all antes refunded</div>
+        <table id="result-table">
+          <thead><tr>
+            <th>Player</th><th>Choice</th><th>Won</th><th>Coord. Credit</th><th>Net</th><th>Balance</th>
+          </tr></thead>
+          <tbody id="result-tbody"></tbody>
+        </table>
+        <div id="result-note" style="font-size:.8rem;color:var(--muted);margin-top:.5rem"></div>
       </div>
     </div>
 
     <!-- Sidebar -->
-    <div id="game-sidebar">
+    <div id="play-sidebar">
       <div id="players-panel">
         <h3>Players</h3>
         <div id="players-list"></div>
@@ -250,730 +238,850 @@ header h1{font-size:1.4rem;letter-spacing:.05em;color:var(--accent)}
       <div id="chat-panel">
         <h3>Chat</h3>
         <div id="chat-messages"></div>
+        <div id="chat-disabled-note" class="hidden">Chat available during commit phase only</div>
         <div id="chat-input-row">
-          <input id="chat-input" type="text" placeholder="Message…" maxlength="300" autocomplete="off"/>
+          <input id="chat-input" type="text" placeholder="Message..." maxlength="300" autocomplete="off"/>
           <button class="btn-ghost" id="chat-send">Send</button>
         </div>
       </div>
     </div>
   </div>
 
-  <!-- ── RESULTS ───────────────────────────────────────────────── -->
-  <div id="results-view" class="view">
-    <div id="results-header">
-      <h2>Round <span id="res-round-num">?</span> Results</h2>
-      <div id="results-countdown">Next round in <span id="res-countdown">12</span>s</div>
-    </div>
-    <div id="cancel-banner" class="hidden">
-      ⚠ Round Cancelled — <span id="cancel-reason"></span>
-    </div>
-    <div id="dot-plot-wrap" class="hidden">
-      <svg id="dot-plot-svg" height="90" viewBox="0 0 800 90" preserveAspectRatio="none"></svg>
-      <div id="stats-row" class="mt1"></div>
-    </div>
-    <div id="results-players"></div>
-    <div id="educational-note"></div>
-  </div>
-
   <!-- ── SUMMARY ───────────────────────────────────────────────── -->
   <div id="summary-view" class="view">
-    <h2>Game Over</h2>
-    <table id="summary-table">
-      <thead>
-        <tr><th>#</th><th>Player</th><th>Final Balance</th><th>Profit/Loss</th></tr>
-      </thead>
-      <tbody id="summary-tbody"></tbody>
-    </table>
-    <div class="flex-row mt2">
-      <button class="btn-primary" id="play-again-btn">Play Again</button>
-      <button class="btn-ghost" id="view-lb-btn">Leaderboard</button>
+    <div class="card">
+      <h2>Game Over</h2>
+      <table id="summary-table">
+        <thead><tr>
+          <th>Player</th><th>Start</th><th>End</th><th>Net</th><th>Status</th>
+        </tr></thead>
+        <tbody id="summary-tbody"></tbody>
+      </table>
+      <div style="display:flex;gap:.5rem;margin-top:1rem;flex-wrap:wrap;align-items:center">
+        <button class="btn-primary" id="requeue-btn">Back to Queue</button>
+        <button class="btn-ghost" id="summary-lb-btn">Leaderboard</button>
+        <div class="toggle-row" style="margin-top:0;margin-left:auto">
+          <input type="checkbox" id="summary-auto-requeue" checked/>
+          <label for="summary-auto-requeue" style="margin:0">Auto-requeue</label>
+        </div>
+      </div>
     </div>
   </div>
 
   <!-- ── LEADERBOARD ───────────────────────────────────────────── -->
   <div id="leaderboard-view" class="view">
-    <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:.75rem">
-      <h2>Global Leaderboard</h2>
-      <button class="btn-ghost" id="lb-back-btn">← Back</button>
+    <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:.75rem;flex-wrap:wrap;gap:.5rem">
+      <h2>Leaderboard</h2>
+      <button class="btn-ghost" id="lb-back-btn">Back</button>
     </div>
-    <div id="my-rank-banner" class="hidden card" style="margin-bottom:.75rem;background:rgba(74,144,217,.08);border-color:var(--accent)"></div>
-    <table id="lb-table">
-      <thead>
-        <tr><th>#</th><th>Player</th><th>Score</th><th>Games</th><th>Coherent %</th><th>Streak</th></tr>
-      </thead>
-      <tbody id="lb-tbody"></tbody>
-    </table>
+    <div id="my-rank-card" class="card hidden"></div>
+    <div class="card">
+      <table id="lb-table">
+        <thead><tr>
+          <th>#</th><th>Player</th><th>Balance</th><th>Games</th><th>Avg/Game</th>
+          <th>Coord%</th><th>Streak</th><th>Best</th>
+        </tr></thead>
+        <tbody id="lb-tbody"></tbody>
+      </table>
+      <div id="lb-empty" class="hidden" style="text-align:center;padding:2rem;color:var(--muted)">No leaderboard data yet.</div>
+    </div>
   </div>
 </div>
 
-<!-- Notifications -->
 <div id="notif"></div>
 
 <script>
+/* ═══════════════════════════════════════════════════════════════════
+   Schelling Game Client
+   Vanilla JS, single-file. Connects via REST + WebSocket.
+   ═══════════════════════════════════════════════════════════════════ */
+(function () {
 'use strict';
-// ─────────────────────────────────────────────────────────────────────
-// State
-// ─────────────────────────────────────────────────────────────────────
-let ws = null;
-let myUsername = '';
-let myRoomCode = '';
-let myBalance = 100;
-let playerBalances = new Map(); // username -> balance
-let currentPhase = 'lobby';
-let currentQuestion = null;
-let myScore = null;       // chosen score (0..1, quantized)
-let mySalt = null;        // hex salt
-let myHash = null;        // sha-256 hex
-let hasCommitted = false;
-let hasRevealed = false;
-let commitDuration = 30;
-let revealDuration = 15;
-let timerEnd = 0;
-let timerRAF = null;
-let resultsTimer = null;
-let resultsEnd = 0;
-let resultsRAF = null;
 
-// ─────────────────────────────────────────────────────────────────────
-// View management
-// ─────────────────────────────────────────────────────────────────────
-const views = {
-  lobby:       document.getElementById('lobby-view'),
-  game:        document.getElementById('game-view'),
-  results:     document.getElementById('results-view'),
-  summary:     document.getElementById('summary-view'),
-  leaderboard: document.getElementById('leaderboard-view'),
+// ── State ───────────────────────────────────────────────────────
+const S = {
+  view: 'auth',
+  walletAddress: null,
+  accountId: null,
+  displayName: null,
+  tokenBalance: 0,
+  autoRequeue: true,
+  // queue
+  inQueue: false,
+  queuedPlayers: [],
+  formingMatch: null,
+  // play
+  matchId: null,
+  players: [],
+  round: 0,
+  phase: null,       // 'commit' | 'reveal' | 'results' | null
+  question: null,
+  selectedOption: null,
+  salt: null,
+  commitHash: null,
+  committed: false,
+  revealed: false,
+  commitStatuses: [],
+  revealStatuses: [],
+  roundResult: null,
+  playerStatuses: {},   // displayName -> 'connected'|'disconnected'|'forfeited'
+  // timers
+  timerEnd: 0,
+  timerDuration: 0,
+  timerInterval: null,
+  // summary
+  summary: null,
+  // leaderboard
+  previousView: 'queue',
+  // ws
+  ws: null,
 };
 
-function showView(name) {
-  Object.entries(views).forEach(([k, el]) => {
-    el.classList.toggle('active', k === name);
-  });
-}
+// ── DOM refs ────────────────────────────────────────────────────
+const $ = (sel) => document.querySelector(sel);
+const $$ = (sel) => document.querySelectorAll(sel);
 
-// ─────────────────────────────────────────────────────────────────────
-// Notifications
-// ─────────────────────────────────────────────────────────────────────
-function notify(text, type = 'info', duration = 3500) {
+// ── Notifications ───────────────────────────────────────────────
+function notify(msg, type = '') {
   const el = document.createElement('div');
-  el.className = `notif-item ${type}`;
-  el.textContent = text;
-  document.getElementById('notif').appendChild(el);
-  setTimeout(() => el.remove(), duration);
+  el.className = 'notif-item ' + type;
+  el.textContent = msg;
+  $('#notif').appendChild(el);
+  setTimeout(() => el.remove(), 4000);
 }
 
-// ─────────────────────────────────────────────────────────────────────
-// WebSocket connection
-// ─────────────────────────────────────────────────────────────────────
-let reconnectAttempts = 0;
-const MAX_RECONNECT_DELAY = 30000;
+// ── View switching ──────────────────────────────────────────────
+function showView(name) {
+  S.view = name;
+  $$('.view').forEach(v => v.classList.remove('active'));
+  $(`#${name}-view`).classList.add('active');
 
-function connect(username, roomCode, roundCount) {
-  if (ws) { try { ws.close(); } catch (_) {} }
+  // header profile
+  if (S.displayName) {
+    $('#header-profile').classList.remove('hidden');
+    $('#header-name').textContent = S.displayName;
+    $('#header-balance').textContent = S.tokenBalance + ' tokens';
+  }
 
-  const proto = location.protocol === 'https:' ? 'wss' : 'ws';
-  ws = new WebSocket(`${proto}://${location.host}/ws?room=${roomCode}`);
-
-  ws.addEventListener('open', () => {
-    reconnectAttempts = 0;
-    ws.send(JSON.stringify({ type: 'join', username, roomCode, roundCount }));
-  });
-
-  ws.addEventListener('message', e => {
-    try { handleServerMessage(JSON.parse(e.data)); }
-    catch (err) { console.error('Message parse error', err); }
-  });
-
-  ws.addEventListener('close', () => {
-    if (!myUsername) return;
-    reconnectAttempts++;
-    const delay = Math.min(1000 * Math.pow(2, reconnectAttempts - 1), MAX_RECONNECT_DELAY);
-    notify(`Disconnected. Reconnecting in ${Math.round(delay / 1000)}s…`, 'error');
-    setTimeout(() => connect(myUsername, myRoomCode, parseInt(document.getElementById('input-rounds').value)), delay);
-  });
-
-  ws.addEventListener('error', () => {});
+  // nav visibility
+  $('#nav-queue').classList.toggle('hidden', name === 'auth');
 }
 
-function sendWs(obj) {
-  if (ws && ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify(obj));
+// ── REST helpers ────────────────────────────────────────────────
+async function api(method, path, body) {
+  const opts = { method, headers: { 'Content-Type': 'application/json' } };
+  if (body) opts.body = JSON.stringify(body);
+  const res = await fetch(path, opts);
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ message: res.statusText }));
+    throw new Error(err.message || res.statusText);
+  }
+  return res.json();
 }
 
-// ─────────────────────────────────────────────────────────────────────
-// Server message handler
-// ─────────────────────────────────────────────────────────────────────
-function handleServerMessage(msg) {
+// ═══════════════════════════════════════════════════════════════
+//  AUTH VIEW
+// ═══════════════════════════════════════════════════════════════
+$('#connect-wallet-btn').addEventListener('click', async () => {
+  const status = $('#auth-status');
+  if (!window.ethereum) {
+    status.textContent = 'MetaMask not detected. Please install it.';
+    return;
+  }
+  try {
+    status.textContent = 'Requesting wallet connection...';
+    const provider = new ethers.BrowserProvider(window.ethereum);
+    const signer = await provider.getSigner();
+    const address = await signer.getAddress();
+    S.walletAddress = address;
+
+    status.textContent = 'Requesting challenge...';
+    const challenge = await api('POST', '/api/auth/challenge', { walletAddress: address });
+
+    status.textContent = 'Please sign the message in your wallet...';
+    const signature = await signer.signMessage(challenge.message);
+
+    status.textContent = 'Verifying signature...';
+    const result = await api('POST', '/api/auth/verify', {
+      challengeId: challenge.challengeId,
+      walletAddress: address,
+      signature,
+    });
+
+    S.accountId = result.accountId;
+    S.tokenBalance = result.tokenBalance;
+
+    if (result.requiresDisplayName) {
+      status.textContent = 'Wallet verified. Please claim a display name.';
+      $('#name-section').classList.remove('hidden');
+      $('#connect-wallet-btn').classList.add('hidden');
+    } else {
+      S.displayName = result.displayName;
+      onAuthComplete();
+    }
+  } catch (err) {
+    status.textContent = 'Error: ' + err.message;
+  }
+});
+
+$('#claim-name-btn').addEventListener('click', async () => {
+  const name = $('#name-input').value.trim();
+  if (!/^[A-Za-z0-9_-]{1,20}$/.test(name)) {
+    $('#auth-status').textContent = 'Invalid name. Use 1-20 chars: A-Z, 0-9, _ or -';
+    return;
+  }
+  try {
+    $('#auth-status').textContent = 'Claiming name...';
+    await api('PATCH', '/api/me/profile', { displayName: name });
+    S.displayName = name;
+    onAuthComplete();
+  } catch (err) {
+    $('#auth-status').textContent = 'Error: ' + err.message;
+  }
+});
+
+function onAuthComplete() {
+  connectWebSocket();
+  showView('queue');
+}
+
+// ── Check existing session on load ──────────────────────────────
+async function checkSession() {
+  try {
+    const me = await api('GET', '/api/me');
+    S.accountId = me.accountId;
+    S.displayName = me.displayName;
+    S.tokenBalance = me.tokenBalance;
+    S.autoRequeue = me.autoRequeue;
+    if (S.displayName) {
+      onAuthComplete();
+    }
+  } catch (_) {
+    // not logged in
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════
+//  WEBSOCKET
+// ═══════════════════════════════════════════════════════════════
+function connectWebSocket() {
+  const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+  S.ws = new WebSocket(`${proto}//${location.host}`);
+  S.ws.onopen = () => {};
+  S.ws.onclose = () => {
+    notify('Connection lost. Reconnecting...', 'warn');
+    setTimeout(connectWebSocket, 2000);
+  };
+  S.ws.onmessage = (evt) => {
+    const msg = JSON.parse(evt.data);
+    handleMessage(msg);
+  };
+}
+
+function wsSend(obj) {
+  if (S.ws && S.ws.readyState === WebSocket.OPEN) {
+    S.ws.send(JSON.stringify(obj));
+  }
+}
+
+function handleMessage(msg) {
   switch (msg.type) {
-    case 'room_state':       return onRoomState(msg);
-    case 'game_started':     return onGameStarted(msg);
-    case 'round_start':      return onRoundStart(msg);
-    case 'commit_status':    return onCommitStatus(msg);
-    case 'phase_change':     return onPhaseChange(msg);
-    case 'reveal_status':    return onRevealStatus(msg);
-    case 'round_result':     return onRoundResult(msg);
-    case 'game_over':        return onGameOver(msg);
-    case 'chat':             return onChat(msg);
-    case 'report_ack':       return notify('Leak reported ✓', 'success', 1500);
-    case 'player_left':      return onPlayerLeft(msg);
-    case 'error':            return notify(msg.message, 'error');
+    case 'queue_state': onQueueState(msg); break;
+    case 'game_started': onGameStarted(msg); break;
+    case 'round_start': onRoundStart(msg); break;
+    case 'commit_status': onCommitStatus(msg); break;
+    case 'phase_change': onPhaseChange(msg); break;
+    case 'reveal_status': onRevealStatus(msg); break;
+    case 'round_result': onRoundResult(msg); break;
+    case 'game_over': onGameOver(msg); break;
+    case 'player_disconnected': onPlayerDisconnected(msg); break;
+    case 'player_reconnected': onPlayerReconnected(msg); break;
+    case 'player_forfeited': onPlayerForfeited(msg); break;
+    case 'chat': onChat(msg); break;
+    case 'error': notify(msg.message, 'error'); break;
+    default: break;
   }
 }
 
-// ─────────────────────────────────────────────────────────────────────
-// Room state
-// ─────────────────────────────────────────────────────────────────────
-function onRoomState(msg) {
-  const { room, players, myBalance: bal } = msg;
-  if (bal !== undefined) myBalance = bal;
-  myRoomCode = room.code;
+// ═══════════════════════════════════════════════════════════════
+//  QUEUE VIEW
+// ═══════════════════════════════════════════════════════════════
+$('#join-queue-btn').addEventListener('click', () => {
+  wsSend({ type: 'join_queue' });
+  S.autoRequeue = true;
+  syncAutoRequeueUI();
+});
 
-  // Update per-player balance map
-  for (const p of players) {
-    if (p.balance !== undefined) playerBalances.set(p.username, p.balance);
+$('#leave-queue-btn').addEventListener('click', () => {
+  wsSend({ type: 'leave_queue' });
+  S.autoRequeue = false;
+  syncAutoRequeueUI();
+});
+
+$('#auto-requeue-toggle').addEventListener('change', (e) => {
+  S.autoRequeue = e.target.checked;
+  // auto-requeue is session state; toggling while not queued is just a preference
+});
+
+function syncAutoRequeueUI() {
+  $('#auto-requeue-toggle').checked = S.autoRequeue;
+  $('#summary-auto-requeue').checked = S.autoRequeue;
+}
+
+function onQueueState(msg) {
+  S.inQueue = msg.status === 'queued';
+  S.queuedPlayers = msg.queuedPlayers || [];
+  S.formingMatch = msg.formingMatch || null;
+  if (msg.autoRequeue !== undefined) {
+    S.autoRequeue = msg.autoRequeue;
+    syncAutoRequeueUI();
   }
 
-  document.getElementById('lobby-room').classList.remove('hidden');
-  document.getElementById('room-code-display').textContent = room.code;
-  document.getElementById('lobby-rounds-display').textContent = room.totalRounds;
+  // ensure we are on queue view if we aren't playing
+  if (S.view === 'auth' || S.view === 'summary') {
+    showView('queue');
+  }
 
-  const isHost = room.host === myUsername;
-  document.getElementById('start-btn').style.display = isHost ? '' : 'none';
-  document.getElementById('waiting-text').style.display = isHost ? 'none' : '';
+  renderQueue();
+}
 
-  const list = document.getElementById('lobby-players');
+function renderQueue() {
+  $('#queue-count').textContent = S.queuedPlayers.length;
+
+  const list = $('#queue-players');
   list.innerHTML = '';
-  for (const p of players) {
-    const chip = document.createElement('div');
-    chip.className = `player-chip${p.isHost ? ' host' : ''}${!p.isConnected ? ' disconnected' : ''}`;
-    chip.textContent = p.username + (p.isHost ? '' : '');
-    list.appendChild(chip);
-  }
+  S.queuedPlayers.forEach(name => {
+    const li = document.createElement('li');
+    li.textContent = name;
+    if (name === S.displayName) li.style.fontWeight = '700';
+    list.appendChild(li);
+  });
 
-  if (room.phase === 'lobby') showView('lobby');
-}
-
-function onPlayerLeft(msg) {
-  const penaltyText = msg.leavePenalty > 0
-    ? ` (penalized ${msg.leavePenalty} chips)`
-    : '';
-  notify(`${msg.username} left the room${penaltyText}`, 'error', 5000);
-}
-
-function onGameStarted(msg) {
-  document.getElementById('total-rounds').textContent = msg.roundCount;
-  currentPhase = 'commit';
-  showView('game');
-  resetChatMessages();
-}
-
-// ─────────────────────────────────────────────────────────────────────
-// Round start
-// ─────────────────────────────────────────────────────────────────────
-function onRoundStart(msg) {
-  const { round, question, commitDuration: cd, phase } = msg;
-  currentQuestion = question;
-  commitDuration = cd;
-  currentPhase = phase;
-  hasCommitted = false;
-  hasRevealed = false;
-  myScore = null;
-  mySalt = null;
-  myHash = null;
-
-  showView('game');
-
-  document.getElementById('round-num').textContent = round;
-  document.getElementById('phase-label').textContent = `Round ${round} / ${document.getElementById('total-rounds').textContent} — Commit Phase`;
-  document.getElementById('phase-label-timer').textContent = 'Commit';
-  document.getElementById('question-text').textContent = question.text;
-
-  // Show correct input
-  const sliderWrap = document.getElementById('slider-wrap');
-  const selectGrid = document.getElementById('select-grid');
-  if (question.type === 'slider') {
-    sliderWrap.classList.remove('hidden');
-    selectGrid.classList.add('hidden');
-    const slider = document.getElementById('slider-input');
-    slider.value = 0.5;
-    document.getElementById('slider-value').textContent = '0.50';
-    myScore = 0.50;
+  // forming match
+  if (S.formingMatch) {
+    $('#forming-banner').classList.remove('hidden');
+    $('#forming-count').textContent = S.formingMatch.playerCount;
+    updateFormingTimer();
   } else {
-    sliderWrap.classList.add('hidden');
-    selectGrid.classList.remove('hidden');
-    renderSelectGrid(question.options);
-    myScore = null;
+    $('#forming-banner').classList.add('hidden');
   }
 
-  // Commit / reveal areas
-  document.getElementById('commit-area').classList.remove('hidden');
-  document.getElementById('reveal-area').classList.add('hidden');
-  document.getElementById('commit-btn').disabled = false;
-  document.getElementById('commit-status-text').textContent = '';
-  document.getElementById('phase-banner').classList.add('hidden');
-
-  startTimer(commitDuration, 'commit');
+  // buttons
+  $('#join-queue-btn').classList.toggle('hidden', S.inQueue);
+  $('#leave-queue-btn').classList.toggle('hidden', !S.inQueue);
 }
 
-function renderSelectGrid(options) {
-  const grid = document.getElementById('select-grid');
+function updateFormingTimer() {
+  if (!S.formingMatch || !S.formingMatch.fillDeadlineMs) {
+    $('#forming-timer').textContent = '--';
+    return;
+  }
+  const remaining = Math.max(0, Math.ceil((S.formingMatch.fillDeadlineMs - Date.now()) / 1000));
+  $('#forming-timer').textContent = remaining;
+}
+
+// Update forming timer every second
+setInterval(updateFormingTimer, 1000);
+
+// ═══════════════════════════════════════════════════════════════
+//  PLAY VIEW
+// ═══════════════════════════════════════════════════════════════
+function onGameStarted(msg) {
+  S.matchId = msg.matchId;
+  S.players = msg.players;
+  S.round = 0;
+  S.phase = null;
+  S.playerStatuses = {};
+  S.players.forEach(p => { S.playerStatuses[p.displayName] = 'connected'; });
+
+  showView('play');
+  renderPlayers();
+  $('#round-result-banner').classList.add('hidden');
+  $('#question-text').textContent = 'Match started. Waiting for first round...';
+  $('#select-grid').innerHTML = '';
+  $('#commit-area').classList.add('hidden');
+  $('#reveal-area').classList.add('hidden');
+  clearChat();
+  notify('Match started with ' + S.players.length + ' players', 'success');
+}
+
+function onRoundStart(msg) {
+  S.round = msg.round;
+  S.phase = 'commit';
+  S.question = msg.question;
+  S.selectedOption = null;
+  S.salt = null;
+  S.commitHash = null;
+  S.committed = false;
+  S.revealed = false;
+  S.commitStatuses = [];
+  S.revealStatuses = [];
+  S.roundResult = null;
+
+  if (S.view !== 'play') showView('play');
+
+  // UI
+  $('#round-num').textContent = msg.round;
+  $('#phase-label').textContent = `Round ${msg.round} / 10 : Commit Phase`;
+  $('#phase-timer-label').textContent = 'Commit';
+  $('#question-text').textContent = msg.question.text;
+  $('#round-result-banner').classList.add('hidden');
+
+  // Render options
+  renderOptions(msg.question.options, false);
+
+  // Show commit, hide reveal
+  $('#commit-area').classList.remove('hidden');
+  $('#commit-btn').disabled = true;
+  $('#commit-status').textContent = '';
+  $('#reveal-area').classList.add('hidden');
+
+  // Timer
+  startTimer(msg.commitDuration);
+
+  // Chat
+  enableChat(true);
+
+  // Reset player dots
+  renderPlayers();
+}
+
+function renderOptions(options, disabled) {
+  const grid = $('#select-grid');
   grid.innerHTML = '';
   options.forEach((opt, idx) => {
-    const card = document.createElement('div');
-    card.className = 'opt-card';
-    card.textContent = opt;
-    card.dataset.idx = idx;
-    card.addEventListener('click', () => {
-      if (hasCommitted) return;
-      grid.querySelectorAll('.opt-card').forEach(c => c.classList.remove('selected'));
-      card.classList.add('selected');
-      myScore = Math.round((idx / Math.max(1, options.length - 1)) * 100) / 100;
-    });
-    grid.appendChild(card);
+    const btn = document.createElement('div');
+    btn.className = 'opt-btn' + (disabled ? ' disabled' : '');
+    btn.textContent = opt;
+    btn.dataset.idx = idx;
+    if (!disabled) {
+      btn.addEventListener('click', () => selectOption(idx));
+    }
+    grid.appendChild(btn);
   });
 }
 
-// ─────────────────────────────────────────────────────────────────────
-// Commit
-// ─────────────────────────────────────────────────────────────────────
-document.getElementById('commit-btn').addEventListener('click', async () => {
-  if (hasCommitted) return;
-  if (myScore === null) return notify('Please select an answer first.', 'error');
+function selectOption(idx) {
+  if (S.committed || S.phase !== 'commit') return;
+  S.selectedOption = idx;
+  $$('.opt-btn').forEach(b => b.classList.toggle('selected', parseInt(b.dataset.idx) === idx));
+  $('#commit-btn').disabled = false;
+}
 
-  const saltBytes = crypto.getRandomValues(new Uint8Array(32));
-  mySalt = Array.from(saltBytes).map(b => b.toString(16).padStart(2, '0')).join('');
+// ── Commit ───────────────────────────────────────────────────────
+$('#commit-btn').addEventListener('click', async () => {
+  if (S.selectedOption === null || S.committed) return;
 
-  const preimage = `${myScore.toFixed(2)}:${mySalt}`;
+  // Generate salt
+  S.salt = Array.from(crypto.getRandomValues(new Uint8Array(16)))
+    .map(b => b.toString(16).padStart(2, '0')).join('');
+
+  // Create hash
+  const preimage = `${S.selectedOption}:${S.salt}`;
   const hashBuf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(preimage));
-  myHash = Array.from(new Uint8Array(hashBuf)).map(b => b.toString(16).padStart(2, '0')).join('');
+  S.commitHash = Array.from(new Uint8Array(hashBuf))
+    .map(b => b.toString(16).padStart(2, '0')).join('');
 
-  hasCommitted = true;
-  document.getElementById('commit-btn').disabled = true;
-  document.getElementById('commit-status-text').textContent = '✓ Committed';
+  wsSend({ type: 'commit', hash: S.commitHash });
+  S.committed = true;
 
-  // Lock input
-  document.getElementById('slider-input').disabled = true;
-  document.getElementById('select-grid').querySelectorAll('.opt-card').forEach(c => c.classList.add('disabled'));
-
-  sendWs({ type: 'commit', hash: myHash });
+  $('#commit-btn').disabled = true;
+  $('#commit-status').textContent = 'Committed. Waiting for others...';
+  $$('.opt-btn').forEach(b => b.classList.add('disabled'));
 });
 
 function onCommitStatus(msg) {
-  renderPlayerList(msg.committed.map(p => ({ ...p, phase: 'commit' })));
+  S.commitStatuses = msg.committed;
+  updatePlayerDots();
 }
 
-// ─────────────────────────────────────────────────────────────────────
-// Reveal phase
-// ─────────────────────────────────────────────────────────────────────
+// ── Phase change to reveal ──────────────────────────────────────
 function onPhaseChange(msg) {
   if (msg.phase === 'reveal') {
-    currentPhase = 'reveal';
-    revealDuration = msg.revealDuration;
-    document.getElementById('phase-label').textContent =
-      `Round ${document.getElementById('round-num').textContent} / ${document.getElementById('total-rounds').textContent} — Reveal Phase`;
-    document.getElementById('phase-label-timer').textContent = 'Reveal';
-    document.getElementById('phase-banner').classList.remove('hidden');
-    document.getElementById('phase-banner').textContent = '👁 Reveal your answer now!';
+    S.phase = 'reveal';
+    $('#phase-label').textContent = `Round ${S.round} / 10 : Reveal Phase`;
+    $('#phase-timer-label').textContent = 'Reveal';
+    $('#commit-area').classList.add('hidden');
 
-    document.getElementById('commit-area').classList.add('hidden');
-    document.getElementById('reveal-area').classList.remove('hidden');
-
-    if (!hasCommitted) {
-      document.getElementById('reveal-btn').disabled = true;
-      document.getElementById('reveal-status-text').textContent = 'You did not commit.';
-    } else if (hasRevealed) {
-      document.getElementById('reveal-btn').disabled = true;
-      document.getElementById('reveal-status-text').textContent = '✓ Revealed';
+    if (S.committed && !S.revealed) {
+      $('#reveal-area').classList.remove('hidden');
+      $('#reveal-status').textContent = '';
+    } else if (!S.committed) {
+      $('#reveal-area').classList.add('hidden');
+      $('#commit-status').textContent = 'You did not commit in time.';
+      $('#commit-area').classList.remove('hidden');
     }
 
-    startTimer(revealDuration, 'reveal');
+    startTimer(msg.revealDuration);
+    enableChat(false);
   }
 }
 
-document.getElementById('reveal-btn').addEventListener('click', () => {
-  if (!hasCommitted || hasRevealed) return;
-  hasRevealed = true;
-  document.getElementById('reveal-btn').disabled = true;
-  document.getElementById('reveal-status-text').textContent = '✓ Revealed';
-  sendWs({ type: 'reveal', score: myScore, salt: mySalt });
+// ── Reveal ───────────────────────────────────────────────────────
+$('#reveal-btn').addEventListener('click', () => {
+  if (S.revealed || S.selectedOption === null || !S.salt) return;
+  wsSend({ type: 'reveal', optionIndex: S.selectedOption, salt: S.salt });
+  S.revealed = true;
+  $('#reveal-btn').disabled = true;
+  $('#reveal-status').textContent = 'Revealed. Waiting for others...';
 });
 
 function onRevealStatus(msg) {
-  renderPlayerList(msg.revealed.map(p => ({ ...p, phase: 'reveal' })));
+  S.revealStatuses = msg.revealed;
+  updatePlayerDots();
 }
 
-// ─────────────────────────────────────────────────────────────────────
-// Round results
-// ─────────────────────────────────────────────────────────────────────
+// ── Round result ─────────────────────────────────────────────────
 function onRoundResult(msg) {
-  clearTimers();
-  const { result } = msg;
-  currentPhase = 'results';
-  showView('results');
+  const r = msg.result;
+  S.roundResult = r;
+  S.phase = 'results';
 
-  document.getElementById('res-round-num').textContent = result.roundNum;
-  document.getElementById('educational-note').textContent = result.educationalNote;
+  $('#phase-label').textContent = `Round ${S.round} / 10 : Results`;
+  $('#phase-timer-label').textContent = 'Results';
+  $('#commit-area').classList.add('hidden');
+  $('#reveal-area').classList.add('hidden');
 
-  const cancelBanner = document.getElementById('cancel-banner');
-  const dotPlotWrap = document.getElementById('dot-plot-wrap');
+  startTimer(12);
 
-  if (result.cancelled) {
-    cancelBanner.classList.remove('hidden');
-    const reasonMap = {
-      fewer_than_2_reveals: 'fewer than 2 players revealed.',
-      sigma_too_small: 'all answers were too similar (σ < 0.02).',
-    };
-    document.getElementById('cancel-reason').textContent = reasonMap[result.cancelReason] || result.cancelReason;
-    dotPlotWrap.classList.add('hidden');
+  // Update local balance
+  const me = r.players.find(p => p.displayName === S.displayName);
+  if (me) {
+    S.tokenBalance = me.newBalance;
+    $('#header-balance').textContent = S.tokenBalance + ' tokens';
+  }
+
+  // Update player balances
+  r.players.forEach(rp => {
+    const sp = S.players.find(p => p.displayName === rp.displayName);
+    if (sp) sp.currentBalance = rp.newBalance;
+  });
+
+  renderRoundResult(r);
+  renderPlayers();
+}
+
+function renderRoundResult(r) {
+  const banner = $('#round-result-banner');
+  banner.classList.remove('hidden');
+  $('#result-round-num').textContent = r.roundNum;
+
+  // Void banner
+  if (r.voided) {
+    $('#void-banner').classList.remove('hidden');
+    $('#void-banner').textContent = 'Round voided: ' + (r.voidReason || 'all antes refunded');
   } else {
-    cancelBanner.classList.add('hidden');
-    dotPlotWrap.classList.remove('hidden');
-    renderDotPlot(result);
-    renderStats(result);
+    $('#void-banner').classList.add('hidden');
   }
 
-  renderResultCards(result);
-
-  // Countdown
-  resultsEnd = Date.now() + 12000;
-  tickResultsCountdown();
-}
-
-function renderDotPlot(result) {
-  const svg = document.getElementById('dot-plot-svg');
-  svg.innerHTML = '';
-  const W = 800, H = 90, PAD = 30;
-  const plotW = W - 2 * PAD;
-
-  const toX = v => PAD + v * plotW;
-
-  // Coherence band
-  if (result.mu !== null && result.sigma !== null) {
-    const lo = Math.max(0, result.mu - 1.25 * result.sigma);
-    const hi = Math.min(1, result.mu + 1.25 * result.sigma);
-    const band = createSVGEl('rect', {
-      x: toX(lo), y: 20, width: toX(hi) - toX(lo), height: 50,
-      fill: 'rgba(74,144,217,0.12)', rx: 4,
-    });
-    svg.appendChild(band);
-  }
-
-  // Axis line
-  const axis = createSVGEl('line', { x1: PAD, y1: 70, x2: W - PAD, y2: 70, stroke: '#333', 'stroke-width': 1 });
-  svg.appendChild(axis);
-
-  // Axis labels
-  ['0.00', '0.25', '0.50', '0.75', '1.00'].forEach(v => {
-    const x = toX(parseFloat(v));
-    const tick = createSVGEl('line', { x1: x, y1: 68, x2: x, y2: 72, stroke: '#444', 'stroke-width': 1 });
-    svg.appendChild(tick);
-    const lbl = createSVGEl('text', { x, y: 84, 'text-anchor': 'middle', fill: '#666', 'font-size': 10 });
-    lbl.textContent = v;
-    svg.appendChild(lbl);
-  });
-
-  // Mu line
-  if (result.mu !== null) {
-    const mx = toX(result.mu);
-    const muLine = createSVGEl('line', { x1: mx, y1: 15, x2: mx, y2: 70, stroke: 'var(--accent)', 'stroke-width': 2, 'stroke-dasharray': '4 3' });
-    svg.appendChild(muLine);
-    const muLbl = createSVGEl('text', { x: mx, y: 12, 'text-anchor': 'middle', fill: 'var(--accent)', 'font-size': 10 });
-    muLbl.textContent = `μ=${result.mu.toFixed(2)}`;
-    svg.appendChild(muLbl);
-  }
-
-  // Dots
-  const scored = (result.players || []).filter(p => p.score !== null);
-  const jitter = new Map();
-  scored.forEach(p => {
-    const x = toX(p.score);
-    const key = Math.round(p.score * 200);
-    const count = jitter.get(key) || 0;
-    jitter.set(key, count + 1);
-    const y = 65 - count * 12;
-    const color = p.coherent ? 'var(--green)' : 'var(--red)';
-    const dot = createSVGEl('circle', { cx: x, cy: y, r: 7, fill: color, opacity: 0.9 });
-    const title = createSVGEl('title');
-    title.textContent = `${p.username}: ${p.score.toFixed(2)}`;
-    dot.appendChild(title);
-    svg.appendChild(dot);
-  });
-}
-
-function renderStats(result) {
-  const row = document.getElementById('stats-row');
-  row.innerHTML = '';
-  const stats = [
-    { label: 'μ (mean)', value: result.mu?.toFixed(4) ?? '—' },
-    { label: 'σ (std dev)', value: result.sigma?.toFixed(4) ?? '—' },
-    { label: 'Coherent', value: (result.players || []).filter(p => p.coherent).length + ' / ' + (result.players || []).length },
-  ];
-  stats.forEach(s => {
-    const pill = document.createElement('div');
-    pill.className = 'stat-pill';
-    pill.innerHTML = `${s.label}: <span>${s.value}</span>`;
-    row.appendChild(pill);
-  });
-}
-
-function renderResultCards(result) {
-  const container = document.getElementById('results-players');
-  container.innerHTML = '';
-  for (const p of (result.players || [])) {
-    const card = document.createElement('div');
-    const coherentClass = result.cancelled ? '' : (p.coherent ? 'coherent' : 'incoherent');
-    card.className = `result-card ${coherentClass}`;
-
-    const delta = (p.reward || 0) - (p.slash || 0);
-    const deltaStr = (delta >= 0 ? '+' : '') + delta.toFixed(2);
-    const deltaClass = delta >= 0 ? 'pos' : 'neg';
-
-    const isMe = p.username === myUsername;
-    if (isMe) myBalance = p.newBalance ?? myBalance;
-    if (p.newBalance !== undefined) playerBalances.set(p.username, p.newBalance);
-
-    card.innerHTML = `
-      <div class="rname">${escHtml(p.username)}${isMe ? ' (you)' : ''}${p.isLeaker ? ' 🚨' : ''}</div>
-      ${p.score !== null ? `<div>Score: <b>${p.score.toFixed(2)}</b></div>` : '<div style="color:var(--muted)">No reveal</div>'}
-      ${!result.cancelled ? `<div>Slash: <span style="color:var(--red)">-${(p.slash||0).toFixed(2)}</span> &nbsp; Reward: <span style="color:var(--green)">+${(p.reward||0).toFixed(2)}</span></div>` : ''}
-      <div class="rdelta ${deltaClass}">${deltaStr} chips → ${(p.newBalance ?? '?')}</div>
-    `;
-    container.appendChild(card);
-  }
-}
-
-function tickResultsCountdown() {
-  if (resultsRAF) cancelAnimationFrame(resultsRAF);
-  const tick = () => {
-    const rem = Math.max(0, Math.ceil((resultsEnd - Date.now()) / 1000));
-    document.getElementById('res-countdown').textContent = rem;
-    if (rem > 0) resultsRAF = requestAnimationFrame(tick);
-  };
-  resultsRAF = requestAnimationFrame(tick);
-}
-
-// ─────────────────────────────────────────────────────────────────────
-// Game over / Summary
-// ─────────────────────────────────────────────────────────────────────
-function onGameOver(msg) {
-  clearTimers();
-  showView('summary');
-  const tbody = document.getElementById('summary-tbody');
+  // Result table
+  const tbody = $('#result-tbody');
   tbody.innerHTML = '';
-  msg.summary.players.forEach((p, i) => {
+  r.players.forEach(p => {
     const tr = document.createElement('tr');
-    const profitClass = p.profit >= 0 ? 'profit-pos' : 'profit-neg';
-    const profitStr = (p.profit >= 0 ? '+' : '') + p.profit;
-    tr.innerHTML = `<td>${i + 1}</td><td>${escHtml(p.username)}${p.username === myUsername ? ' (you)' : ''}</td><td>${p.finalBalance}</td><td class="${profitClass}">${profitStr}</td>`;
+    const optLabel = p.revealedOptionIndex !== null && p.revealedOptionIndex !== undefined && S.question
+      ? (S.question.options[p.revealedOptionIndex] || '?')
+      : '-';
+    const deltaClass = p.netDelta > 0 ? 'delta-pos' : (p.netDelta < 0 ? 'delta-neg' : 'delta-zero');
+    const deltaStr = p.netDelta > 0 ? '+' + p.netDelta : String(p.netDelta);
+
+    tr.innerHTML = `
+      <td>${esc(p.displayName)}</td>
+      <td>${esc(optLabel)}</td>
+      <td class="${p.wonRound ? 'won-yes' : 'won-no'}">${p.wonRound ? 'Yes' : 'No'}</td>
+      <td class="${p.earnsCoordinationCredit ? 'credit-yes' : ''}">${p.earnsCoordinationCredit ? 'Yes' : 'No'}</td>
+      <td class="${deltaClass}">${deltaStr}</td>
+      <td>${p.newBalance}</td>
+    `;
     tbody.appendChild(tr);
   });
-}
 
-document.getElementById('play-again-btn').addEventListener('click', () => {
-  showView('lobby');
-  document.getElementById('lobby-room').classList.remove('hidden');
-});
-
-document.getElementById('view-lb-btn').addEventListener('click', () => loadLeaderboard());
-
-// ─────────────────────────────────────────────────────────────────────
-// Chat
-// ─────────────────────────────────────────────────────────────────────
-function onChat(msg) {
-  addChatMessage(msg.from, msg.text, msg.messageId, msg.from !== myUsername);
-}
-
-function addChatMessage(from, text, messageId, canReport) {
-  const container = document.getElementById('chat-messages');
-  const el = document.createElement('div');
-  el.className = 'chat-msg';
-  el.dataset.msgId = messageId;
-  el.innerHTML = `<span class="from">${escHtml(from)}</span>${escHtml(text)}`;
-  if (canReport && currentPhase === 'commit') {
-    const btn = document.createElement('button');
-    btn.className = 'report-btn';
-    btn.title = 'Report as leak';
-    btn.textContent = '⚑';
-    btn.addEventListener('click', () => {
-      sendWs({ type: 'report_leak', messageId, suspectUsername: from });
-      btn.disabled = true;
-      btn.textContent = '✓';
-    });
-    el.appendChild(btn);
+  // Note about solo wins
+  const note = $('#result-note');
+  if (!r.voided) {
+    const hasWinnerNoCredit = r.players.some(p => p.wonRound && !p.earnsCoordinationCredit);
+    if (hasWinnerNoCredit) {
+      note.textContent = 'Solo win: won the pot but no coordination credit earned (topCount=1). Does not extend streak.';
+    } else {
+      note.textContent = '';
+    }
+  } else {
+    note.textContent = '';
   }
-  container.appendChild(el);
-  container.scrollTop = container.scrollHeight;
 }
 
-function resetChatMessages() {
-  document.getElementById('chat-messages').innerHTML = '';
+// ── Player status dots ──────────────────────────────────────────
+function updatePlayerDots() {
+  $$('.player-row .dot').forEach(dot => {
+    const name = dot.dataset.name;
+    if (!name) return;
+
+    // Check forfeited / disconnected first
+    if (S.playerStatuses[name] === 'forfeited') {
+      dot.className = 'dot forfeited';
+      return;
+    }
+    if (S.playerStatuses[name] === 'disconnected') {
+      dot.className = 'dot disconnected';
+      return;
+    }
+
+    // Commit/reveal status
+    const c = S.commitStatuses.find(s => s.displayName === name);
+    const r = S.revealStatuses.find(s => s.displayName === name);
+    if (r && r.hasRevealed) {
+      dot.className = 'dot revealed';
+    } else if (c && c.hasCommitted) {
+      dot.className = 'dot committed';
+    } else {
+      dot.className = 'dot';
+    }
+  });
 }
 
-document.getElementById('chat-send').addEventListener('click', sendChat);
-document.getElementById('chat-input').addEventListener('keydown', e => {
+function renderPlayers() {
+  const list = $('#players-list');
+  list.innerHTML = '';
+  S.players.forEach(p => {
+    const row = document.createElement('div');
+    row.className = 'player-row';
+    const bal = p.currentBalance !== undefined ? p.currentBalance : p.startingBalance;
+    const statusClass = S.playerStatuses[p.displayName] || '';
+    row.innerHTML = `
+      <div class="player-name">
+        <span class="dot ${statusClass}" data-name="${esc(p.displayName)}"></span>
+        <span>${esc(p.displayName)}</span>
+      </div>
+      <span class="balance-badge">${bal}</span>
+    `;
+    list.appendChild(row);
+  });
+  updatePlayerDots();
+}
+
+// ── Player events ───────────────────────────────────────────────
+function onPlayerDisconnected(msg) {
+  S.playerStatuses[msg.displayName] = 'disconnected';
+  notify(msg.displayName + ' disconnected (' + msg.graceSeconds + 's grace)', 'warn');
+  updatePlayerDots();
+}
+
+function onPlayerReconnected(msg) {
+  S.playerStatuses[msg.displayName] = 'connected';
+  notify(msg.displayName + ' reconnected', 'success');
+  updatePlayerDots();
+}
+
+function onPlayerForfeited(msg) {
+  S.playerStatuses[msg.displayName] = 'forfeited';
+  notify(msg.displayName + ' forfeited', 'error');
+  updatePlayerDots();
+}
+
+// ── Timer ────────────────────────────────────────────────────────
+function startTimer(seconds) {
+  clearInterval(S.timerInterval);
+  S.timerDuration = seconds;
+  S.timerEnd = Date.now() + seconds * 1000;
+  tickTimer();
+  S.timerInterval = setInterval(tickTimer, 250);
+}
+
+function tickTimer() {
+  const remaining = Math.max(0, (S.timerEnd - Date.now()) / 1000);
+  const pct = Math.max(0, remaining / S.timerDuration * 100);
+  const bar = $('#timer-bar');
+  const num = $('#timer-num');
+  bar.style.width = pct + '%';
+  num.textContent = Math.ceil(remaining);
+  if (remaining <= 5) {
+    bar.style.background = 'var(--red)';
+    num.classList.add('urgent');
+  } else {
+    bar.style.background = 'var(--accent)';
+    num.classList.remove('urgent');
+  }
+  if (remaining <= 0) clearInterval(S.timerInterval);
+}
+
+// ── Chat ─────────────────────────────────────────────────────────
+function enableChat(enabled) {
+  $('#chat-input').disabled = !enabled;
+  $('#chat-send').disabled = !enabled;
+  $('#chat-disabled-note').classList.toggle('hidden', enabled);
+  $('#chat-input-row').classList.toggle('hidden', !enabled);
+}
+
+function clearChat() {
+  $('#chat-messages').innerHTML = '';
+}
+
+$('#chat-send').addEventListener('click', sendChat);
+$('#chat-input').addEventListener('keydown', (e) => {
   if (e.key === 'Enter') sendChat();
 });
 
 function sendChat() {
-  const input = document.getElementById('chat-input');
+  const input = $('#chat-input');
   const text = input.value.trim();
   if (!text) return;
-  if (currentPhase !== 'commit' && currentPhase !== 'lobby') {
-    return notify('Chat is only available during commit phase or lobby.', 'error');
-  }
+  wsSend({ type: 'chat', text });
   input.value = '';
-  sendWs({ type: 'chat', text });
 }
 
-// ─────────────────────────────────────────────────────────────────────
-// Slider
-// ─────────────────────────────────────────────────────────────────────
-document.getElementById('slider-input').addEventListener('input', e => {
-  const v = Math.round(parseFloat(e.target.value) * 100) / 100;
-  document.getElementById('slider-value').textContent = v.toFixed(2);
-  myScore = v;
+function onChat(msg) {
+  const container = $('#chat-messages');
+  const div = document.createElement('div');
+  div.className = 'chat-msg';
+  div.innerHTML = `<span class="from">${esc(msg.from)}:</span>${esc(msg.text)}`;
+  container.appendChild(div);
+  container.scrollTop = container.scrollHeight;
+}
+
+// ═══════════════════════════════════════════════════════════════
+//  GAME OVER / SUMMARY
+// ═══════════════════════════════════════════════════════════════
+function onGameOver(msg) {
+  S.summary = msg.summary;
+  S.matchId = null;
+  S.phase = null;
+  clearInterval(S.timerInterval);
+
+  // Update own balance from summary
+  const me = msg.summary.players.find(p => p.displayName === S.displayName);
+  if (me) {
+    S.tokenBalance = me.endingBalance;
+    $('#header-balance').textContent = S.tokenBalance + ' tokens';
+  }
+
+  showView('summary');
+  renderSummary(msg.summary);
+  syncAutoRequeueUI();
+}
+
+function renderSummary(summary) {
+  const tbody = $('#summary-tbody');
+  tbody.innerHTML = '';
+  summary.players.forEach(p => {
+    const tr = document.createElement('tr');
+    const deltaClass = p.netDelta > 0 ? 'delta-pos' : (p.netDelta < 0 ? 'delta-neg' : 'delta-zero');
+    const deltaStr = p.netDelta > 0 ? '+' + p.netDelta : String(p.netDelta);
+    tr.innerHTML = `
+      <td>${esc(p.displayName)}</td>
+      <td>${p.startingBalance}</td>
+      <td>${p.endingBalance}</td>
+      <td class="${deltaClass}">${deltaStr}</td>
+      <td>${p.result === 'forfeited' ? 'Forfeited' : 'Completed'}</td>
+    `;
+    tbody.appendChild(tr);
+  });
+}
+
+$('#requeue-btn').addEventListener('click', () => {
+  S.autoRequeue = true;
+  syncAutoRequeueUI();
+  wsSend({ type: 'join_queue' });
+  showView('queue');
 });
 
-// ─────────────────────────────────────────────────────────────────────
-// Timer
-// ─────────────────────────────────────────────────────────────────────
-function startTimer(duration, phase) {
-  clearTimerAnim();
-  timerEnd = Date.now() + duration * 1000;
-  const bar = document.getElementById('timer-bar');
-  const num = document.getElementById('timer-num');
-  bar.style.background = phase === 'commit' ? 'var(--accent)' : 'var(--orange)';
-
-  const tick = () => {
-    const elapsed = Date.now() - (timerEnd - duration * 1000);
-    const remaining = Math.max(0, (timerEnd - Date.now()) / 1000);
-    const pct = Math.max(0, (1 - elapsed / (duration * 1000)) * 100);
-    bar.style.width = pct + '%';
-    num.textContent = Math.ceil(remaining);
-
-    if (remaining <= 5) {
-      bar.style.background = 'var(--red)';
-      num.classList.add('pulse');
-    } else {
-      num.classList.remove('pulse');
-    }
-    if (remaining > 0) timerRAF = requestAnimationFrame(tick);
-  };
-  timerRAF = requestAnimationFrame(tick);
-}
-
-function clearTimerAnim() {
-  if (timerRAF) { cancelAnimationFrame(timerRAF); timerRAF = null; }
-}
-
-function clearTimers() {
-  clearTimerAnim();
-  if (resultsRAF) { cancelAnimationFrame(resultsRAF); resultsRAF = null; }
-}
-
-// ─────────────────────────────────────────────────────────────────────
-// Players list (game sidebar)
-// ─────────────────────────────────────────────────────────────────────
-function renderPlayerList(statuses) {
-  const list = document.getElementById('players-list');
-  list.innerHTML = '';
-  for (const p of statuses) {
-    const row = document.createElement('div');
-    row.className = 'player-row';
-    const hasAct = p.hasCommitted || p.hasRevealed;
-    const dotClass = p.hasRevealed ? 'revealed' : (p.hasCommitted ? 'committed' : '');
-    row.innerHTML = `
-      <div class="player-name">
-        <div class="dot ${dotClass}"></div>
-        ${escHtml(p.username)}${p.username === myUsername ? ' (you)' : ''}
-      </div>
-      <div class="balance-badge">${playerBalances.get(p.username) ?? (p.username === myUsername ? myBalance : '?')} ⬡</div>
-    `;
-    list.appendChild(row);
+$('#summary-auto-requeue').addEventListener('change', (e) => {
+  S.autoRequeue = e.target.checked;
+  if (!S.autoRequeue) {
+    wsSend({ type: 'leave_queue' });
   }
-}
+});
 
-// ─────────────────────────────────────────────────────────────────────
-// Leaderboard
-// ─────────────────────────────────────────────────────────────────────
+$('#summary-lb-btn').addEventListener('click', () => {
+  S.previousView = 'summary';
+  loadLeaderboard();
+});
+
+// ═══════════════════════════════════════════════════════════════
+//  LEADERBOARD
+// ═══════════════════════════════════════════════════════════════
+$('#nav-leaderboard').addEventListener('click', () => {
+  S.previousView = S.view;
+  loadLeaderboard();
+});
+
+$('#lb-back-btn').addEventListener('click', () => {
+  showView(S.previousView || 'queue');
+});
+
+$('#nav-queue').addEventListener('click', () => {
+  showView('queue');
+});
+
 async function loadLeaderboard() {
   showView('leaderboard');
   try {
-    const [rows, me] = await Promise.all([
-      fetch('/api/leaderboard').then(r => r.json()),
-      myUsername ? fetch(`/api/leaderboard/me?username=${encodeURIComponent(myUsername)}`).then(r => r.ok ? r.json() : null) : Promise.resolve(null),
+    const [entries, myRank] = await Promise.all([
+      api('GET', '/api/leaderboard'),
+      api('GET', '/api/leaderboard/me').catch(() => null),
     ]);
 
-    const tbody = document.getElementById('lb-tbody');
-    tbody.innerHTML = '';
-    rows.forEach((p, i) => {
-      const pct = p.rounds_played > 0 ? Math.round(p.coherent_rounds / p.rounds_played * 100) : 0;
-      const tr = document.createElement('tr');
-      if (p.username === myUsername) tr.className = 'me';
-      tr.innerHTML = `<td>${i + 1}</td><td>${escHtml(p.username)}</td><td>${p.global_score}</td><td>${p.games_played}</td><td>${pct}%</td><td>${p.longest_streak}</td>`;
-      tbody.appendChild(tr);
-    });
-
-    const banner = document.getElementById('my-rank-banner');
-    if (me && me.rank) {
-      banner.classList.remove('hidden');
-      const pct = me.rounds_played > 0 ? Math.round(me.coherent_rounds / me.rounds_played * 100) : 0;
-      banner.innerHTML = `<b>${escHtml(me.username)}</b> — Rank #${me.rank} &nbsp;|&nbsp; Score: ${me.global_score} &nbsp;|&nbsp; Coherent: ${pct}% &nbsp;|&nbsp; Streak: ${me.longest_streak}`;
-    } else {
-      banner.classList.add('hidden');
-    }
+    renderLeaderboard(entries, myRank);
   } catch (err) {
     notify('Failed to load leaderboard: ' + err.message, 'error');
   }
 }
 
-// ─────────────────────────────────────────────────────────────────────
-// Navigation
-// ─────────────────────────────────────────────────────────────────────
-document.getElementById('nav-leaderboard').addEventListener('click', loadLeaderboard);
-document.getElementById('nav-lobby').addEventListener('click', () => showView('lobby'));
-document.getElementById('lb-back-btn').addEventListener('click', () => {
-  showView(currentPhase === 'results' ? 'results' : currentPhase === 'commit' || currentPhase === 'reveal' ? 'game' : 'lobby');
-});
+function renderLeaderboard(entries, myRank) {
+  const tbody = $('#lb-tbody');
+  tbody.innerHTML = '';
 
-// ─────────────────────────────────────────────────────────────────────
-// Lobby / Join
-// ─────────────────────────────────────────────────────────────────────
-document.getElementById('join-btn').addEventListener('click', () => {
-  const username = document.getElementById('input-username').value.trim();
-  const roomCode = document.getElementById('input-roomcode').value.trim().toUpperCase() || generateCode();
-  const roundCount = parseInt(document.getElementById('input-rounds').value);
+  if (!entries || entries.length === 0) {
+    $('#lb-empty').classList.remove('hidden');
+    return;
+  }
+  $('#lb-empty').classList.add('hidden');
 
-  if (!username) return notify('Please enter a username.', 'error');
-  if (!/^[A-Za-z0-9_\-]{1,20}$/.test(username)) return notify('Username: 1-20 alphanumeric chars only.', 'error');
+  entries.forEach(e => {
+    const tr = document.createElement('tr');
+    if (e.displayName === S.displayName) tr.className = 'me';
+    tr.innerHTML = `
+      <td>${e.rank}</td>
+      <td>${esc(e.displayName)}</td>
+      <td>${e.tokenBalance}</td>
+      <td>${e.gamesPlayed}</td>
+      <td>${e.avgNetTokensPerGame !== undefined ? e.avgNetTokensPerGame.toFixed(1) : '-'}</td>
+      <td>${e.coherentPct !== undefined ? e.coherentPct + '%' : '-'}</td>
+      <td>${e.currentStreak || 0}</td>
+      <td>${e.longestStreak || 0}</td>
+    `;
+    tbody.appendChild(tr);
+  });
 
-  myUsername = username;
-  myRoomCode = roomCode;
-  document.getElementById('input-roomcode').value = roomCode;
-
-  connect(username, roomCode, roundCount);
-});
-
-document.getElementById('start-btn').addEventListener('click', () => {
-  sendWs({ type: 'start_game' });
-});
-
-function generateCode() {
-  const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
-  return Array.from({ length: 6 }, () => chars[Math.floor(Math.random() * chars.length)]).join('');
+  // My rank card
+  const card = $('#my-rank-card');
+  if (myRank) {
+    card.classList.remove('hidden');
+    card.innerHTML = `
+      <div style="font-size:.9rem">
+        Your rank: <strong>#${myRank.rank}</strong>
+        | Balance: <strong>${myRank.tokenBalance}</strong>
+        | Coordination: <strong>${myRank.coherentPct || 0}%</strong>
+        | Streak: <strong>${myRank.currentStreak || 0}</strong> (best: ${myRank.longestStreak || 0})
+      </div>
+    `;
+  } else {
+    card.classList.add('hidden');
+  }
 }
 
-// ─────────────────────────────────────────────────────────────────────
-// Utils
-// ─────────────────────────────────────────────────────────────────────
-function escHtml(str) {
-  return String(str).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+// ═══════════════════════════════════════════════════════════════
+//  UTILITIES
+// ═══════════════════════════════════════════════════════════════
+function esc(str) {
+  const d = document.createElement('div');
+  d.textContent = str;
+  return d.innerHTML;
 }
 
-function createSVGEl(tag, attrs = {}) {
-  const el = document.createElementNS('http://www.w3.org/2000/svg', tag);
-  Object.entries(attrs).forEach(([k, v]) => el.setAttribute(k, v));
-  return el;
-}
+// ── Boot ─────────────────────────────────────────────────────────
+checkSession();
+
+})();
 </script>
 </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -4,7 +4,8 @@ import { fileURLToPath } from 'node:url';
 import express from 'express';
 import { WebSocketServer } from 'ws';
 import db from './src/db.js';
-import { handleMessage, handleDisconnect } from './src/gameManager.js';
+import { createChallenge, verifyChallenge, getSession, isValidAddress } from './src/auth.js';
+import { handleMessage, handleDisconnect, sessionState } from './src/gameManager.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -12,26 +13,161 @@ const PORT = process.env.PORT || 3000;
 
 const app = express();
 app.use(express.json());
-app.use(express.static(path.join(__dirname, 'public')));
 
 // ---------------------------------------------------------------------------
-// REST API
+// Cookie helpers
 // ---------------------------------------------------------------------------
 
-app.get('/api/leaderboard', (_req, res) => {
+function parseCookies(cookieHeader) {
+  const cookies = {};
+  if (!cookieHeader) return cookies;
+  for (const pair of cookieHeader.split(';')) {
+    const [name, ...rest] = pair.trim().split('=');
+    cookies[name] = rest.join('=');
+  }
+  return cookies;
+}
+
+function resolveAccountId(req) {
+  const cookieHeader = req.headers.cookie;
+  const cookies = parseCookies(cookieHeader);
+  const token = cookies.session;
+  if (!token) return null;
+  const session = getSession(token);
+  if (!session) return null;
+  return session.accountId;
+}
+
+// ---------------------------------------------------------------------------
+// Middleware
+// ---------------------------------------------------------------------------
+
+// Attach accountId to every request when a valid session cookie is present.
+app.use((req, _res, next) => {
+  req.accountId = resolveAccountId(req);
+  next();
+});
+
+// Guard for routes that require authentication.
+function authenticateSession(req, res, next) {
+  if (!req.accountId) {
+    return res.status(401).json({ error: 'Authentication required' });
+  }
+  next();
+}
+
+// ---------------------------------------------------------------------------
+// REST API: Auth
+// ---------------------------------------------------------------------------
+
+app.post('/api/auth/challenge', (req, res) => {
   try {
-    const rows = db.getLeaderboard(50);
+    const { walletAddress } = req.body;
+    if (!walletAddress || !isValidAddress(walletAddress)) {
+      return res.status(400).json({ error: 'Invalid or missing walletAddress' });
+    }
+    const result = createChallenge(walletAddress);
+    res.json(result);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/api/auth/verify', (req, res) => {
+  try {
+    const { challengeId, walletAddress, signature } = req.body;
+    if (!challengeId || !walletAddress || !signature) {
+      return res.status(400).json({ error: 'challengeId, walletAddress, and signature are required' });
+    }
+
+    const { sessionToken, account } = verifyChallenge({ challengeId, walletAddress, signature });
+
+    res.setHeader(
+      'Set-Cookie',
+      `session=${sessionToken}; HttpOnly; SameSite=Strict; Path=/`,
+    );
+
+    res.json(account);
+  } catch (err) {
+    res.status(401).json({ error: err.message });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// REST API: Profile
+// ---------------------------------------------------------------------------
+
+app.get('/api/me', authenticateSession, (req, res) => {
+  try {
+    const account = db.getAccount(req.accountId);
+    if (!account) return res.status(404).json({ error: 'Account not found' });
+
+    const queueStatus = typeof sessionState?.getQueueStatus === 'function'
+      ? sessionState.getQueueStatus(req.accountId)
+      : null;
+
+    res.json({
+      accountId: account.account_id,
+      displayName: account.display_name,
+      tokenBalance: account.token_balance,
+      leaderboardEligible: !!account.leaderboard_eligible,
+      autoRequeue: false,
+      queueStatus,
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.patch('/api/me/profile', authenticateSession, (req, res) => {
+  try {
+    const { displayName } = req.body;
+    if (!displayName || !/^[A-Za-z0-9_-]{1,20}$/.test(displayName)) {
+      return res.status(400).json({ error: 'displayName must match ^[A-Za-z0-9_-]{1,20}$' });
+    }
+
+    // Prevent name changes while queued or in a match.
+    const queueStatus = typeof sessionState?.getQueueStatus === 'function'
+      ? sessionState.getQueueStatus(req.accountId)
+      : null;
+    if (queueStatus && (queueStatus.state === 'queued' || queueStatus.state === 'in_match')) {
+      return res.status(409).json({ error: 'Cannot change display name while queued or in a match' });
+    }
+
+    db.setDisplayName(req.accountId, displayName);
+    const updated = db.getAccount(req.accountId);
+
+    res.json({
+      accountId: updated.account_id,
+      displayName: updated.display_name,
+      tokenBalance: updated.token_balance,
+      leaderboardEligible: !!updated.leaderboard_eligible,
+    });
+  } catch (err) {
+    if (err.message.includes('already taken')) {
+      return res.status(409).json({ error: err.message });
+    }
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// REST API: Leaderboard
+// ---------------------------------------------------------------------------
+
+app.get('/api/leaderboard', (req, res) => {
+  try {
+    const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 50, 1), 200);
+    const rows = db.getLeaderboard(limit);
     res.json(rows);
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
 });
 
-app.get('/api/leaderboard/me', (req, res) => {
-  const { username } = req.query;
-  if (!username) return res.status(400).json({ error: 'username query param required' });
+app.get('/api/leaderboard/me', authenticateSession, (req, res) => {
   try {
-    const player = db.getPlayerRank(username);
+    const player = db.getPlayerRank(req.accountId);
     if (!player) return res.status(404).json({ error: 'Player not found' });
     res.json(player);
   } catch (err) {
@@ -39,18 +175,75 @@ app.get('/api/leaderboard/me', (req, res) => {
   }
 });
 
+// ---------------------------------------------------------------------------
+// REST API: CSV export
+// ---------------------------------------------------------------------------
+
 app.get('/api/export/votes.csv', (_req, res) => {
   try {
     const rows = db.getAllVoteLogs();
     const headers = [
-      'id','session_id','round_number','question_id','username',
-      'revealed_score','mu','sigma','is_coherent','slash_amount',
-      'reward_amount','is_leaker','player_count','timestamp',
+      'id',
+      'match_id',
+      'round_number',
+      'question_id',
+      'account_id',
+      'display_name',
+      'revealed_option_index',
+      'revealed_option_label',
+      'won_round',
+      'earns_coordination_credit',
+      'ante_amount',
+      'round_payout',
+      'net_delta',
+      'player_count',
+      'valid_reveal_count',
+      'top_count',
+      'winner_count',
+      'winning_option_indexes',
+      'voided',
+      'void_reason',
+      'timestamp',
     ];
+
+    // Map DB column names to canonical CSV column names.
+    const colMap = {
+      id: 'id',
+      match_id: 'match_id',
+      round_number: 'round_number',
+      question_id: 'question_id',
+      account_id: 'account_id',
+      display_name_snapshot: 'display_name',
+      revealed_option_index: 'revealed_option_index',
+      revealed_option_label: 'revealed_option_label',
+      won_round: 'won_round',
+      earns_coordination_credit: 'earns_coordination_credit',
+      ante_amount: 'ante_amount',
+      round_payout: 'round_payout',
+      net_delta: 'net_delta',
+      player_count: 'player_count',
+      valid_reveal_count: 'valid_reveal_count',
+      top_count: 'top_count',
+      winner_count: 'winner_count',
+      winning_option_indexes_json: 'winning_option_indexes',
+      voided: 'voided',
+      void_reason: 'void_reason',
+      timestamp: 'timestamp',
+    };
+
+    // Build an inverted map: canonical name -> DB column name.
+    const reverseMap = {};
+    for (const [dbCol, csvCol] of Object.entries(colMap)) {
+      reverseMap[csvCol] = dbCol;
+    }
+
     const csv = [
       headers.join(','),
-      ...rows.map(r => headers.map(h => JSON.stringify(r[h] ?? '')).join(',')),
+      ...rows.map(r =>
+        headers.map(h => JSON.stringify(r[reverseMap[h]] ?? '')).join(','),
+      ),
     ].join('\n');
+
     res.setHeader('Content-Type', 'text/csv');
     res.setHeader('Content-Disposition', 'attachment; filename="votes.csv"');
     res.send(csv);
@@ -60,13 +253,48 @@ app.get('/api/export/votes.csv', (_req, res) => {
 });
 
 // ---------------------------------------------------------------------------
-// WebSocket
+// REST API: Admin
+// ---------------------------------------------------------------------------
+
+app.post('/api/admin/leaderboard-eligible', (req, res) => {
+  try {
+    const { accountId, eligible } = req.body;
+    if (!accountId) return res.status(400).json({ error: 'accountId required' });
+    if (typeof eligible !== 'boolean') return res.status(400).json({ error: 'eligible must be a boolean' });
+
+    db.setLeaderboardEligible(accountId, eligible);
+    res.json({ accountId, eligible });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Static files
+// ---------------------------------------------------------------------------
+
+app.use(express.static(path.join(__dirname, 'public')));
+
+// ---------------------------------------------------------------------------
+// HTTP + WebSocket server
 // ---------------------------------------------------------------------------
 
 const server = http.createServer(app);
 const wss = new WebSocketServer({ server });
 
-wss.on('connection', (ws) => {
+wss.on('connection', (ws, req) => {
+  // Authenticate via session cookie from the upgrade request.
+  const cookies = parseCookies(req.headers.cookie);
+  const session = getSession(cookies.session);
+
+  if (!session) {
+    ws.send(JSON.stringify({ type: 'error', message: 'Authentication required' }));
+    ws.close(4001, 'Unauthenticated');
+    return;
+  }
+
+  ws._accountId = session.accountId;
+
   ws.on('message', (data) => {
     handleMessage(ws, data.toString());
   });
@@ -84,4 +312,4 @@ server.listen(PORT, () => {
   console.log(`Schelling Game server running on http://localhost:${PORT}`);
 });
 
-export default server; // for testing
+export default server;

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,0 +1,120 @@
+import { ethers } from 'ethers';
+import crypto from 'node:crypto';
+import db from './db.js';
+
+const CHALLENGE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const sessions = new Map(); // sessionToken -> { accountId, createdAt }
+
+/**
+ * Create an auth challenge for a wallet address.
+ * @param {string} walletAddress - Ethereum address (0x...)
+ * @returns {{ challengeId, message, expiresAt }}
+ */
+export function createChallenge(walletAddress) {
+  // Normalize to checksum address
+  const normalized = ethers.getAddress(walletAddress);
+  const nonce = crypto.randomBytes(32).toString('hex');
+  const challengeId = `ch_${crypto.randomBytes(16).toString('hex')}`;
+  const expiresAt = new Date(Date.now() + CHALLENGE_TTL_MS).toISOString();
+  const message = `Sign this message to authenticate with Schelling Game.\n\nWallet: ${normalized}\nNonce: ${nonce}\nExpires: ${expiresAt}`;
+
+  db.createChallenge({ challengeId, walletAddress: normalized, message, nonce, expiresAt });
+
+  return { challengeId, message, expiresAt };
+}
+
+/**
+ * Verify a signed challenge and establish a session.
+ * @param {{ challengeId, walletAddress, signature }} params
+ * @returns {{ sessionToken, account }}
+ * @throws {Error} on invalid/expired challenge or bad signature
+ */
+export function verifyChallenge({ challengeId, walletAddress, signature }) {
+  const normalized = ethers.getAddress(walletAddress);
+  const challenge = db.getChallenge(challengeId);
+  if (!challenge) throw new Error('Challenge not found or already used');
+  if (challenge.wallet_address !== normalized) throw new Error('Wallet address mismatch');
+  if (new Date(challenge.expires_at) < new Date()) throw new Error('Challenge expired');
+
+  // Verify the signature
+  const recoveredAddress = ethers.verifyMessage(challenge.message, signature);
+  if (recoveredAddress.toLowerCase() !== normalized.toLowerCase()) {
+    throw new Error('Signature verification failed');
+  }
+
+  // Mark challenge as used
+  db.markChallengeUsed(challengeId);
+
+  // Upsert account
+  db.upsertAccount(normalized);
+  const account = db.getAccount(normalized);
+
+  // Create session
+  const sessionToken = crypto.randomBytes(32).toString('hex');
+  sessions.set(sessionToken, { accountId: normalized, createdAt: Date.now() });
+
+  return {
+    sessionToken,
+    account: {
+      accountId: account.account_id,
+      displayName: account.display_name,
+      requiresDisplayName: !account.display_name,
+      tokenBalance: account.token_balance,
+      leaderboardEligible: !!account.leaderboard_eligible,
+    },
+  };
+}
+
+/**
+ * Get account from session token.
+ * @param {string} sessionToken
+ * @returns {object|null} account info or null
+ */
+export function getSession(sessionToken) {
+  if (!sessionToken) return null;
+  const session = sessions.get(sessionToken);
+  if (!session) return null;
+  return session;
+}
+
+/**
+ * Remove a session.
+ */
+export function destroySession(sessionToken) {
+  sessions.delete(sessionToken);
+}
+
+/**
+ * Validate an Ethereum address format.
+ */
+export function isValidAddress(address) {
+  try {
+    ethers.getAddress(address);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Dev-mode shortcut: create a session without wallet signing
+// Only use when NODE_ENV !== 'production'
+export function devCreateSession(walletAddress) {
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error('Dev sessions not allowed in production');
+  }
+  const normalized = walletAddress.toLowerCase();
+  db.upsertAccount(normalized);
+  const account = db.getAccount(normalized);
+  const sessionToken = crypto.randomBytes(32).toString('hex');
+  sessions.set(sessionToken, { accountId: normalized, createdAt: Date.now() });
+  return {
+    sessionToken,
+    account: {
+      accountId: account.account_id,
+      displayName: account.display_name,
+      requiresDisplayName: !account.display_name,
+      tokenBalance: account.token_balance,
+      leaderboardEligible: !!account.leaderboard_eligible,
+    },
+  };
+}

--- a/src/db.js
+++ b/src/db.js
@@ -19,100 +19,190 @@ function getDb() {
 
 function initSchema() {
   db.exec(`
-    CREATE TABLE IF NOT EXISTS players (
-      username        TEXT PRIMARY KEY,
-      global_score    INTEGER DEFAULT 0,
+    CREATE TABLE IF NOT EXISTS accounts (
+      account_id           TEXT PRIMARY KEY,
+      display_name         TEXT UNIQUE,
+      token_balance        INTEGER DEFAULT 0,
+      leaderboard_eligible INTEGER DEFAULT 0,
+      created_at           TEXT DEFAULT (datetime('now'))
+    );
+
+    CREATE TABLE IF NOT EXISTS player_stats (
+      account_id      TEXT PRIMARY KEY REFERENCES accounts(account_id),
       games_played    INTEGER DEFAULT 0,
       rounds_played   INTEGER DEFAULT 0,
       coherent_rounds INTEGER DEFAULT 0,
-      longest_streak  INTEGER DEFAULT 0,
       current_streak  INTEGER DEFAULT 0,
-      created_at      TEXT DEFAULT (datetime('now'))
+      longest_streak  INTEGER DEFAULT 0
+    );
+
+    CREATE TABLE IF NOT EXISTS auth_challenges (
+      challenge_id   TEXT PRIMARY KEY,
+      wallet_address TEXT NOT NULL,
+      message        TEXT NOT NULL,
+      nonce          TEXT NOT NULL,
+      expires_at     TEXT NOT NULL,
+      used           INTEGER DEFAULT 0
+    );
+
+    CREATE TABLE IF NOT EXISTS matches (
+      match_id     TEXT PRIMARY KEY,
+      started_at   TEXT DEFAULT (datetime('now')),
+      ended_at     TEXT,
+      round_count  INTEGER DEFAULT 10,
+      player_count INTEGER,
+      status       TEXT DEFAULT 'active'
+    );
+
+    CREATE TABLE IF NOT EXISTS match_players (
+      match_id              TEXT REFERENCES matches(match_id),
+      account_id            TEXT REFERENCES accounts(account_id),
+      display_name_snapshot TEXT,
+      starting_balance      INTEGER,
+      ending_balance        INTEGER,
+      net_delta             INTEGER,
+      result                TEXT DEFAULT 'active',
+      PRIMARY KEY (match_id, account_id)
     );
 
     CREATE TABLE IF NOT EXISTS vote_logs (
-      id             INTEGER PRIMARY KEY AUTOINCREMENT,
-      session_id     TEXT,
-      round_number   INTEGER,
-      question_id    INTEGER,
-      username       TEXT,
-      revealed_score REAL,
-      mu             REAL,
-      sigma          REAL,
-      is_coherent    INTEGER,
-      slash_amount   REAL,
-      reward_amount  REAL,
-      is_leaker      INTEGER,
-      player_count   INTEGER,
-      timestamp      TEXT DEFAULT (datetime('now'))
+      id                          INTEGER PRIMARY KEY AUTOINCREMENT,
+      match_id                    TEXT,
+      round_number                INTEGER,
+      question_id                 INTEGER,
+      account_id                  TEXT,
+      display_name_snapshot       TEXT,
+      revealed_option_index       INTEGER,
+      revealed_option_label       TEXT,
+      won_round                   INTEGER,
+      earns_coordination_credit   INTEGER,
+      ante_amount                 INTEGER DEFAULT 60,
+      round_payout                INTEGER DEFAULT 0,
+      net_delta                   INTEGER DEFAULT 0,
+      player_count                INTEGER,
+      valid_reveal_count          INTEGER,
+      top_count                   INTEGER,
+      winner_count                INTEGER,
+      winning_option_indexes_json TEXT,
+      voided                      INTEGER DEFAULT 0,
+      void_reason                 TEXT,
+      timestamp                   TEXT DEFAULT (datetime('now'))
     );
   `);
 }
 
 // ---------------------------------------------------------------------------
-// Player queries
+// Auth challenge queries
 // ---------------------------------------------------------------------------
 
-function upsertPlayer(username) {
+function createChallenge({ challengeId, walletAddress, message, nonce, expiresAt }) {
+  getDb().prepare(`
+    INSERT INTO auth_challenges (challenge_id, wallet_address, message, nonce, expires_at)
+    VALUES (?, ?, ?, ?, ?)
+  `).run(challengeId, walletAddress, message, nonce, expiresAt);
+}
+
+function getChallenge(challengeId) {
+  const row = getDb().prepare(
+    'SELECT * FROM auth_challenges WHERE challenge_id = ?'
+  ).get(challengeId);
+  if (!row) return null;
+  if (row.used) return null;
+  if (new Date(row.expires_at) < new Date()) return null;
+  return row;
+}
+
+function markChallengeUsed(challengeId) {
+  getDb().prepare(
+    'UPDATE auth_challenges SET used = 1 WHERE challenge_id = ?'
+  ).run(challengeId);
+}
+
+// ---------------------------------------------------------------------------
+// Account queries
+// ---------------------------------------------------------------------------
+
+function upsertAccount(accountId) {
   const d = getDb();
   d.prepare(`
-    INSERT INTO players (username) VALUES (?)
-    ON CONFLICT(username) DO NOTHING
-  `).run(username);
-}
-
-function getPlayer(username) {
-  return getDb().prepare('SELECT * FROM players WHERE username = ?').get(username);
-}
-
-function getLeaderboard(limit = 50) {
-  return getDb()
-    .prepare('SELECT * FROM players ORDER BY global_score DESC, coherent_rounds DESC LIMIT ?')
-    .all(limit);
-}
-
-function getPlayerRank(username) {
-  const d = getDb();
-  const player = d.prepare('SELECT * FROM players WHERE username = ?').get(username);
-  if (!player) return null;
-  const rank = d.prepare(
-    'SELECT COUNT(*) as rank FROM players WHERE global_score > ?'
-  ).get(player.global_score).rank + 1;
-  return { ...player, rank };
-}
-
-/**
- * Update player stats after a game ends.
- * @param {string} username
- * @param {object} stats - { roundsPlayed, coherentRounds, scoreChange }
- */
-function updatePlayerStats(username, stats) {
-  const d = getDb();
-  upsertPlayer(username);
-  const player = d.prepare('SELECT * FROM players WHERE username = ?').get(username);
-
-  // Streak: add coherent rounds if any; reset only if player played rounds but had zero coherent ones
-  const hadIncoherence = stats.roundsPlayed > 0 && stats.coherentRounds === 0;
-  const newStreak = hadIncoherence ? 0 : (player.current_streak + stats.coherentRounds);
-  const longestStreak = Math.max(player.longest_streak, newStreak);
-
+    INSERT INTO accounts (account_id) VALUES (?)
+    ON CONFLICT(account_id) DO NOTHING
+  `).run(accountId);
   d.prepare(`
-    UPDATE players SET
-      global_score    = global_score + ?,
-      games_played    = games_played + 1,
-      rounds_played   = rounds_played + ?,
-      coherent_rounds = coherent_rounds + ?,
-      current_streak  = ?,
-      longest_streak  = ?
-    WHERE username = ?
-  `).run(
-    Math.round(stats.scoreChange),
-    stats.roundsPlayed,
-    stats.coherentRounds,
-    newStreak,
-    longestStreak,
-    username,
-  );
+    INSERT INTO player_stats (account_id) VALUES (?)
+    ON CONFLICT(account_id) DO NOTHING
+  `).run(accountId);
+}
+
+function getAccount(accountId) {
+  return getDb().prepare(`
+    SELECT a.*, s.games_played, s.rounds_played, s.coherent_rounds,
+           s.current_streak, s.longest_streak
+    FROM accounts a
+    LEFT JOIN player_stats s ON a.account_id = s.account_id
+    WHERE a.account_id = ?
+  `).get(accountId);
+}
+
+function setDisplayName(accountId, displayName) {
+  const d = getDb();
+  const existing = d.prepare(
+    'SELECT account_id FROM accounts WHERE display_name = ? AND account_id != ?'
+  ).get(displayName, accountId);
+  if (existing) {
+    throw new Error(`Display name "${displayName}" is already taken`);
+  }
+  d.prepare(
+    'UPDATE accounts SET display_name = ? WHERE account_id = ?'
+  ).run(displayName, accountId);
+}
+
+function getAccountByDisplayName(displayName) {
+  return getDb().prepare(`
+    SELECT a.*, s.games_played, s.rounds_played, s.coherent_rounds,
+           s.current_streak, s.longest_streak
+    FROM accounts a
+    LEFT JOIN player_stats s ON a.account_id = s.account_id
+    WHERE a.display_name = ?
+  `).get(displayName);
+}
+
+function updateBalance(accountId, delta) {
+  getDb().prepare(
+    'UPDATE accounts SET token_balance = token_balance + ? WHERE account_id = ?'
+  ).run(delta, accountId);
+}
+
+// ---------------------------------------------------------------------------
+// Match queries
+// ---------------------------------------------------------------------------
+
+function createMatch({ matchId, playerCount }) {
+  getDb().prepare(`
+    INSERT INTO matches (match_id, player_count) VALUES (?, ?)
+  `).run(matchId, playerCount);
+}
+
+function addMatchPlayer({ matchId, accountId, displayNameSnapshot, startingBalance }) {
+  getDb().prepare(`
+    INSERT INTO match_players (match_id, account_id, display_name_snapshot, starting_balance)
+    VALUES (?, ?, ?, ?)
+  `).run(matchId, accountId, displayNameSnapshot, startingBalance);
+}
+
+function updateMatchPlayer({ matchId, accountId, endingBalance, netDelta, result }) {
+  getDb().prepare(`
+    UPDATE match_players
+    SET ending_balance = ?, net_delta = ?, result = ?
+    WHERE match_id = ? AND account_id = ?
+  `).run(endingBalance, netDelta, result, matchId, accountId);
+}
+
+function endMatch(matchId) {
+  getDb().prepare(`
+    UPDATE matches SET ended_at = datetime('now'), status = 'completed'
+    WHERE match_id = ?
+  `).run(matchId);
 }
 
 // ---------------------------------------------------------------------------
@@ -122,22 +212,31 @@ function updatePlayerStats(username, stats) {
 function insertVoteLog(entry) {
   getDb().prepare(`
     INSERT INTO vote_logs
-      (session_id, round_number, question_id, username, revealed_score,
-       mu, sigma, is_coherent, slash_amount, reward_amount, is_leaker, player_count)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      (match_id, round_number, question_id, account_id, display_name_snapshot,
+       revealed_option_index, revealed_option_label, won_round, earns_coordination_credit,
+       ante_amount, round_payout, net_delta, player_count, valid_reveal_count,
+       top_count, winner_count, winning_option_indexes_json, voided, void_reason)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
-    entry.sessionId,
+    entry.matchId,
     entry.roundNumber,
     entry.questionId,
-    entry.username,
-    entry.revealedScore ?? null,
-    entry.mu ?? null,
-    entry.sigma ?? null,
-    entry.isCoherent ? 1 : 0,
-    entry.slashAmount,
-    entry.rewardAmount,
-    entry.isLeaker ? 1 : 0,
+    entry.accountId,
+    entry.displayNameSnapshot,
+    entry.revealedOptionIndex ?? null,
+    entry.revealedOptionLabel ?? null,
+    entry.wonRound ? 1 : 0,
+    entry.earnsCoordinationCredit ? 1 : 0,
+    entry.anteAmount ?? 60,
+    entry.roundPayout ?? 0,
+    entry.netDelta ?? 0,
     entry.playerCount,
+    entry.validRevealCount ?? null,
+    entry.topCount ?? null,
+    entry.winnerCount ?? null,
+    entry.winningOptionIndexesJson ?? null,
+    entry.voided ? 1 : 0,
+    entry.voidReason ?? null,
   );
 }
 
@@ -145,13 +244,165 @@ function getAllVoteLogs() {
   return getDb().prepare('SELECT * FROM vote_logs ORDER BY id ASC').all();
 }
 
+// ---------------------------------------------------------------------------
+// Player stats
+// ---------------------------------------------------------------------------
+
+function updatePlayerStats(accountId, { roundsPlayed, coherentRounds, isGameEnd, wonRound, earnsCoordinationCredit }) {
+  const d = getDb();
+
+  const stats = d.prepare('SELECT * FROM player_stats WHERE account_id = ?').get(accountId);
+  if (!stats) return;
+
+  let newStreak = stats.current_streak;
+
+  if (earnsCoordinationCredit) {
+    // Coordination credit: increment streak
+    newStreak = stats.current_streak + 1;
+  } else if (wonRound) {
+    // Won round but topCount was 1 (no coordination credit): break streak
+    newStreak = 0;
+  } else {
+    // Lost round: break streak
+    newStreak = 0;
+  }
+
+  const longestStreak = Math.max(stats.longest_streak, newStreak);
+
+  const gamesIncrement = isGameEnd ? 1 : 0;
+
+  d.prepare(`
+    UPDATE player_stats SET
+      games_played    = games_played + ?,
+      rounds_played   = rounds_played + ?,
+      coherent_rounds = coherent_rounds + ?,
+      current_streak  = ?,
+      longest_streak  = ?
+    WHERE account_id = ?
+  `).run(
+    gamesIncrement,
+    roundsPlayed ?? 0,
+    coherentRounds ?? 0,
+    newStreak,
+    longestStreak,
+    accountId,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Leaderboard
+// ---------------------------------------------------------------------------
+
+function getLeaderboard(limit = 50) {
+  return getDb().prepare(`
+    SELECT
+      ROW_NUMBER() OVER (
+        ORDER BY a.token_balance DESC, s.coherent_rounds DESC, a.display_name ASC
+      ) AS rank,
+      a.display_name AS displayName,
+      a.token_balance AS tokenBalance,
+      a.leaderboard_eligible AS leaderboardEligible,
+      s.games_played AS gamesPlayed,
+      s.rounds_played AS roundsPlayed,
+      s.coherent_rounds AS coherentRounds,
+      CASE WHEN s.rounds_played > 0
+        THEN ROUND(100.0 * s.coherent_rounds / s.rounds_played, 1)
+        ELSE 0
+      END AS coherentPct,
+      s.current_streak AS currentStreak,
+      s.longest_streak AS longestStreak,
+      CASE WHEN s.games_played > 0
+        THEN ROUND(1.0 * a.token_balance / s.games_played, 1)
+        ELSE 0
+      END AS avgNetTokensPerGame
+    FROM accounts a
+    JOIN player_stats s ON a.account_id = s.account_id
+    WHERE a.leaderboard_eligible = 1
+    ORDER BY a.token_balance DESC, s.coherent_rounds DESC, a.display_name ASC
+    LIMIT ?
+  `).all(limit);
+}
+
+function getPlayerRank(accountId) {
+  const d = getDb();
+
+  const row = d.prepare(`
+    SELECT
+      a.account_id,
+      a.display_name AS displayName,
+      a.token_balance AS tokenBalance,
+      a.leaderboard_eligible AS leaderboardEligible,
+      s.games_played AS gamesPlayed,
+      s.rounds_played AS roundsPlayed,
+      s.coherent_rounds AS coherentRounds,
+      CASE WHEN s.rounds_played > 0
+        THEN ROUND(100.0 * s.coherent_rounds / s.rounds_played, 1)
+        ELSE 0
+      END AS coherentPct,
+      s.current_streak AS currentStreak,
+      s.longest_streak AS longestStreak,
+      CASE WHEN s.games_played > 0
+        THEN ROUND(1.0 * a.token_balance / s.games_played, 1)
+        ELSE 0
+      END AS avgNetTokensPerGame
+    FROM accounts a
+    JOIN player_stats s ON a.account_id = s.account_id
+    WHERE a.account_id = ?
+  `).get(accountId);
+
+  if (!row) return null;
+
+  const rank = d.prepare(`
+    SELECT COUNT(*) + 1 AS rank
+    FROM accounts a2
+    JOIN player_stats s2 ON a2.account_id = s2.account_id
+    WHERE a2.leaderboard_eligible = 1
+      AND (
+        a2.token_balance > ?
+        OR (a2.token_balance = ? AND s2.coherent_rounds > ?)
+        OR (a2.token_balance = ? AND s2.coherent_rounds = ? AND a2.display_name < ?)
+      )
+  `).get(
+    row.tokenBalance,
+    row.tokenBalance, row.coherentRounds,
+    row.tokenBalance, row.coherentRounds, row.displayName ?? '',
+  ).rank;
+
+  return { ...row, rank };
+}
+
+// ---------------------------------------------------------------------------
+// Leaderboard eligibility
+// ---------------------------------------------------------------------------
+
+function setLeaderboardEligible(accountId, eligible) {
+  getDb().prepare(
+    'UPDATE accounts SET leaderboard_eligible = ? WHERE account_id = ?'
+  ).run(eligible ? 1 : 0, accountId);
+}
+
+// ---------------------------------------------------------------------------
+// Export
+// ---------------------------------------------------------------------------
+
 export default {
   getDb,
-  upsertPlayer,
-  getPlayer,
-  getLeaderboard,
-  getPlayerRank,
-  updatePlayerStats,
+  createChallenge,
+  getChallenge,
+  markChallengeUsed,
+  upsertAccount,
+  getAccount,
+  setDisplayName,
+  getAccountByDisplayName,
+  updateBalance,
+  createMatch,
+  addMatchPlayer,
+  updateMatchPlayer,
+  endMatch,
   insertVoteLog,
   getAllVoteLogs,
+  updatePlayerStats,
+  getLeaderboard,
+  getPlayerRank,
+  setLeaderboardEligible,
 };

--- a/src/domain/commitReveal.js
+++ b/src/domain/commitReveal.js
@@ -1,0 +1,30 @@
+import crypto from 'node:crypto';
+
+// Preimage format: "${optionIndex}:${salt}"
+// Hash: SHA-256 hex digest
+
+export function createCommitHash(optionIndex, salt) {
+  const preimage = `${optionIndex}:${salt}`;
+  return crypto.createHash('sha256').update(preimage).digest('hex');
+}
+
+export function verifyCommit(optionIndex, salt, hash) {
+  return createCommitHash(optionIndex, salt) === hash;
+}
+
+// Validate salt: must be hex string, at least 32 chars (128 bits)
+export function validateSalt(salt) {
+  if (typeof salt !== 'string') return false;
+  if (salt.length < 32) return false;
+  return /^[0-9a-f]+$/i.test(salt);
+}
+
+// Validate commit hash format
+export function validateHash(hash) {
+  return typeof hash === 'string' && /^[0-9a-f]{64}$/.test(hash);
+}
+
+// Validate optionIndex: must be non-negative integer within option count
+export function validateOptionIndex(optionIndex, optionCount) {
+  return Number.isInteger(optionIndex) && optionIndex >= 0 && optionIndex < optionCount;
+}

--- a/src/domain/questions.js
+++ b/src/domain/questions.js
@@ -1,0 +1,99 @@
+import crypto from 'node:crypto';
+
+/**
+ * Canonical question pool for Schelling Game.
+ * Select-only questions that fit the focal-point policy.
+ */
+const QUESTION_POOL = [
+  { id: 1,  text: "Pick a number.", type: "select", category: "number", options: ["1","2","3","4","5","6","7","8","9","10"] },
+  { id: 2,  text: "Pick a Fibonacci number.", type: "select", category: "number", options: ["1","2","3","5","8","13","21","34","55","89"] },
+  { id: 3,  text: "Pick a perfect square.", type: "select", category: "number", options: ["1","4","9","16","25","36","49","64","81","100"] },
+  { id: 4,  text: "Pick a prime number.", type: "select", category: "number", options: ["2","3","5","7","11","13","17","19","23","29","31","37"] },
+  { id: 5,  text: "Pick a multiple of ten.", type: "select", category: "number", options: ["10","20","30","40","50","60","70","80","90","100"] },
+  { id: 6,  text: "Pick a digit.", type: "select", category: "number", options: ["0","1","2","3","4","5","6","7","8","9"] },
+  { id: 7,  text: "Pick a number.", type: "select", category: "number", options: ["3","7","12","22","35","42","58","69","77","88","91","100"] },
+  { id: 8,  text: "Pick a probability.", type: "select", category: "number", options: ["0.01","0.05","0.10","0.25","0.33","0.50","0.67","0.75","0.90","0.95","0.99"] },
+  { id: 9,  text: "Pick a power of two.", type: "select", category: "number", options: ["1","2","4","8","16","32","64","128","256","512","1024"] },
+  { id: 10, text: "Pick a number.", type: "select", category: "number", options: ["1","2","3","4","5","6","7","8","9","1000"] },
+  { id: 11, text: "Pick a number.", type: "select", category: "number", options: ["-50","-20","-10","-5","-1","0","1","5","10","20","50"] },
+  { id: 12, text: "Pick a repeating number.", type: "select", category: "number", options: ["11","22","33","44","55","66","77","88","99","111"] },
+  { id: 13, text: "Pick a decimal.", type: "select", category: "number", options: ["0.0","0.1","0.2","0.3","0.4","0.5","0.6","0.7","0.8","0.9","1.0"] },
+  { id: 14, text: "Pick a constant.", type: "select", category: "number", options: ["0","1","e (2.72)","pi (3.14)","phi (1.62)","sqrt2 (1.41)","ln2 (0.69)","42","infinity","-1"] },
+  { id: 15, text: "Pick a percentage.", type: "select", category: "number", options: ["0%","10%","20%","30%","40%","50%","60%","70%","80%","90%","100%"] },
+  { id: 16, text: "Pick the best age to be.", type: "select", category: "lifestyle", options: ["5","10","16","18","21","25","30","40","50","65","80"] },
+  { id: 17, text: "Pick the best time of day.", type: "select", category: "lifestyle", options: ["06:00","07:00","08:00","10:00","12:00","14:00","17:00","19:00","20:00","22:00","00:00"] },
+  { id: 18, text: "Pick the best month.", type: "select", category: "lifestyle", options: ["January","February","March","April","May","June","July","August","September","October","November","December"] },
+  { id: 19, text: "Pick the best day of the week.", type: "select", category: "lifestyle", options: ["Monday","Tuesday","Wednesday","Thursday","Friday","Saturday","Sunday"] },
+  { id: 20, text: "Pick the decade with the best music.", type: "select", category: "culture", options: ["1920s","1930s","1940s","1950s","1960s","1970s","1980s","1990s","2000s","2010s","2020s"] },
+  { id: 21, text: "How long should a perfect vacation last?", type: "select", category: "lifestyle", options: ["1 day","3 days","1 week","2 weeks","1 month","3 months","6 months","1 year","5 years","Forever"] },
+  { id: 22, text: "Pick the most powerful human emotion.", type: "select", category: "psychology", options: ["Joy","Sadness","Anger","Fear","Surprise","Disgust","Love","Hope","Curiosity","Peace"] },
+  { id: 23, text: "Pick the best superpower.", type: "select", category: "fantasy", options: ["Flight","Invisibility","Teleportation","Time travel","Mind reading","Super strength","Immortality","Shapeshifting","Telekinesis","Healing others"] },
+  { id: 24, text: "If you could eat only one food forever, which?", type: "select", category: "lifestyle", options: ["Rice","Bread","Potato","Pasta","Corn","Chicken","Beef","Fish","Eggs","Cheese"] },
+  { id: 25, text: "Which sense is most important?", type: "select", category: "psychology", options: ["Smell","Taste","Touch","Hearing","Sight"] },
+  { id: 26, text: "Pick the most interesting number.", type: "select", category: "number", options: ["Zero","One","Two","Three","Five","Seven","Ten","Twelve","Thirteen","Forty-two","Hundred","Infinity"] },
+  { id: 27, text: "Pick the most important virtue.", type: "select", category: "philosophy", options: ["Courage","Wisdom","Justice","Temperance","Honesty","Compassion","Loyalty","Humility","Patience","Gratitude"] },
+  { id: 28, text: "Pick the most universal human fear.", type: "select", category: "psychology", options: ["Heights","Darkness","Spiders","Snakes","Death","Loneliness","Failure","Deep water","Public speaking","The unknown"] },
+  { id: 29, text: "Pick the most beautiful color.", type: "select", category: "aesthetics", options: ["Red","Orange","Yellow","Green","Teal","Blue","Indigo","Violet","Pink","Gold","Black","White"] },
+  { id: 30, text: "Pick the most beautiful time of year.", type: "select", category: "aesthetics", options: ["Early spring","Late spring","Early summer","Midsummer","Late summer","Early autumn","Mid autumn","Late autumn","Early winter","Midwinter"] },
+  { id: 31, text: "Pick the most beautiful-sounding instrument.", type: "select", category: "aesthetics", options: ["Piano","Guitar","Violin","Cello","Flute","Trumpet","Saxophone","Harp","Drums","Human voice"] },
+  { id: 32, text: "Pick the word that best describes life.", type: "select", category: "philosophy", options: ["Always","Never","Sometimes","Maybe","Definitely","Probably","Rarely","Often","Impossible","Unpredictable"] },
+  { id: 33, text: "Pick what matters most.", type: "select", category: "philosophy", options: ["Freedom","Security","Love","Power","Knowledge","Peace","Wealth","Health","Truth","Beauty"] },
+  { id: 34, text: "Pick the fundamental principle of the universe.", type: "select", category: "philosophy", options: ["Order","Chaos","Balance","Change","Stillness","Growth","Decay","Cycles","Entropy","Emergence"] },
+  { id: 35, text: "Pick the most important concept.", type: "select", category: "philosophy", options: ["Past","Present","Future","Moment","Eternity","Memory","Dream","Now","Change","Permanence"] },
+  { id: 36, text: "Pick the warmest color.", type: "select", category: "aesthetics", options: ["White","Light yellow","Yellow","Gold","Orange","Coral","Red","Crimson","Maroon","Brown","Dark brown","Black"] },
+  { id: 37, text: "Pick the coldest color.", type: "select", category: "aesthetics", options: ["White","Ice blue","Light cyan","Cyan","Teal","Blue","Navy","Indigo","Dark purple","Charcoal","Black"] },
+  { id: 38, text: "Pick the shade that best represents 'neutral'.", type: "select", category: "aesthetics", options: ["White","Ivory","Light gray","Silver","Gray","Slate","Dark gray","Charcoal","Near-black","Black"] },
+  { id: 39, text: "Pick the color of trust.", type: "select", category: "aesthetics", options: ["Red","Orange","Yellow","Green","Teal","Blue","Indigo","Violet","White","Gold","Black","Gray"] },
+  { id: 40, text: "Pick the color of danger.", type: "select", category: "aesthetics", options: ["White","Yellow","Gold","Orange","Coral","Red","Crimson","Maroon","Dark red","Black"] },
+  { id: 41, text: "Pick the most calming color.", type: "select", category: "aesthetics", options: ["White","Lavender","Light blue","Sky blue","Mint","Sage","Seafoam","Teal","Periwinkle","Soft pink","Cream","Gray"] },
+  { id: 42, text: "Pick the color that represents 'moderate'.", type: "select", category: "aesthetics", options: ["Pure red","Warm red","Orange-red","Orange","Amber","Neutral","Teal","Cool blue","Blue","Deep blue"] },
+  { id: 43, text: "Pick the color of intelligence.", type: "select", category: "aesthetics", options: ["Red","Orange","Yellow","Green","Teal","Blue","Indigo","Violet","Silver","Gold","White","Black"] },
+  { id: 44, text: "Pick the color of money.", type: "select", category: "aesthetics", options: ["White","Cream","Light green","Green","Dark green","Gold","Silver","Brown","Blue","Black"] },
+  { id: 45, text: "Pick the color of the future.", type: "select", category: "aesthetics", options: ["White","Silver","Light blue","Cyan","Teal","Electric blue","Purple","Violet","Neon green","Chrome","Black"] },
+];
+
+/**
+ * Returns a deep copy of the full canonical question pool.
+ */
+export function getPublicPool() {
+  return JSON.parse(JSON.stringify(QUESTION_POOL));
+}
+
+/**
+ * Select `count` questions randomly without replacement.
+ * Uses crypto.getRandomValues for unbiased shuffling.
+ *
+ * @param {number} count - number of questions to select (default 10)
+ * @returns {Array<object>} selected questions (deep copies)
+ */
+export function selectQuestionsForMatch(count = 10) {
+  const pool = getPublicPool();
+  if (count > pool.length) {
+    throw new RangeError(
+      `Requested ${count} questions but pool only has ${pool.length}`
+    );
+  }
+
+  // Fisher-Yates shuffle using crypto randomness
+  for (let i = pool.length - 1; i > 0; i--) {
+    const buf = new Uint32Array(1);
+    crypto.getRandomValues(buf);
+    const j = buf[0] % (i + 1);
+    [pool[i], pool[j]] = [pool[j], pool[i]];
+  }
+
+  return pool.slice(0, count);
+}
+
+/**
+ * Validates that every question in the pool is a select type with an options array.
+ *
+ * @returns {boolean}
+ */
+export function validatePool() {
+  return QUESTION_POOL.every(
+    q => q.type === 'select' && Array.isArray(q.options) && q.options.length > 0
+  );
+}
+
+export default QUESTION_POOL;

--- a/src/domain/settlement.js
+++ b/src/domain/settlement.js
@@ -1,0 +1,110 @@
+const ROUND_ANTE = 60;
+
+/**
+ * Settle a round using exact-match plurality.
+ *
+ * @param {Array<{accountId, displayName, optionIndex: number|null, validReveal: boolean, forfeited: boolean, attached: boolean}>} players
+ * @param {object} question - { id, text, options }
+ * @returns {object} round result
+ */
+export function settleRound(players, question) {
+  const attached = players.filter(p => p.attached);
+  const roundPlayerCount = attached.length;
+  const pot = roundPlayerCount * ROUND_ANTE;
+
+  // Collect valid reveals
+  const validReveals = players.filter(p => p.validReveal);
+  const validRevealCount = validReveals.length;
+
+  // Zero valid reveals: void
+  if (validRevealCount === 0) {
+    return buildVoidResult(players, question, roundPlayerCount, 'zero_valid_reveals');
+  }
+
+  // Count votes per option
+  const optionCounts = new Map();
+  for (const p of validReveals) {
+    optionCounts.set(p.optionIndex, (optionCounts.get(p.optionIndex) || 0) + 1);
+  }
+
+  // Find topCount and winning options
+  const topCount = Math.max(...optionCounts.values());
+  const winningOptionIndexes = [];
+  for (const [idx, count] of optionCounts) {
+    if (count === topCount) winningOptionIndexes.push(idx);
+  }
+  winningOptionIndexes.sort((a, b) => a - b);
+
+  // Determine winners
+  const winnerSet = new Set();
+  for (const p of validReveals) {
+    if (winningOptionIndexes.includes(p.optionIndex)) {
+      winnerSet.add(p.accountId);
+    }
+  }
+  const winnerCount = winnerSet.size;
+  const payoutPerWinner = Math.floor(pot / winnerCount);
+
+  // Build player results
+  const playerResults = attached.map(p => {
+    const wonRound = winnerSet.has(p.accountId);
+    const earnsCoordinationCredit = wonRound && topCount >= 2;
+    const antePaid = ROUND_ANTE;
+    const roundPayout = wonRound ? payoutPerWinner : 0;
+    const netDelta = roundPayout - antePaid;
+
+    return {
+      accountId: p.accountId,
+      displayName: p.displayName,
+      revealedOptionIndex: p.validReveal ? p.optionIndex : null,
+      revealedOptionLabel: p.validReveal && p.optionIndex != null ? (question.options[p.optionIndex] || null) : null,
+      wonRound,
+      earnsCoordinationCredit,
+      antePaid,
+      roundPayout,
+      netDelta,
+    };
+  });
+
+  return {
+    voided: false,
+    voidReason: null,
+    playerCount: roundPlayerCount,
+    pot,
+    validRevealCount,
+    topCount,
+    winningOptionIndexes,
+    winnerCount,
+    payoutPerWinner,
+    players: playerResults,
+  };
+}
+
+function buildVoidResult(players, question, roundPlayerCount, reason) {
+  const playerResults = players.filter(p => p.attached).map(p => ({
+    accountId: p.accountId,
+    displayName: p.displayName,
+    revealedOptionIndex: null,
+    revealedOptionLabel: null,
+    wonRound: false,
+    earnsCoordinationCredit: false,
+    antePaid: 0,
+    roundPayout: 0,
+    netDelta: 0,
+  }));
+
+  return {
+    voided: true,
+    voidReason: reason,
+    playerCount: roundPlayerCount,
+    pot: 0,
+    validRevealCount: 0,
+    topCount: 0,
+    winningOptionIndexes: [],
+    winnerCount: 0,
+    payoutPerWinner: 0,
+    players: playerResults,
+  };
+}
+
+export { ROUND_ANTE };

--- a/src/gameManager.js
+++ b/src/gameManager.js
@@ -1,539 +1,776 @@
 import { v4 as uuidv4 } from 'uuid';
-import { verifyCommit, computeRoundResult, applyBalanceChanges, computeLeavePenalty } from './gameLogic.js';
+import queue from './matchmaking.js';
+import { verifyCommit, validateSalt, validateHash, validateOptionIndex } from './domain/commitReveal.js';
+import { settleRound, ROUND_ANTE } from './domain/settlement.js';
+import { selectQuestionsForMatch } from './domain/questions.js';
 import db from './db.js';
-import QUESTIONS from './questions.js';
 
-const STARTING_BALANCE = 1000;
-const ROUND_STAKE = 100;
-const COMMIT_DURATION_NORMAL = 30;   // seconds
-const COMMIT_DURATION_ESTIMATION = 60;
-const REVEAL_DURATION = 15;
-const RESULTS_DURATION = 12;
+const COMMIT_DURATION = 30;    // seconds
+const REVEAL_DURATION = 15;    // seconds
+const RESULTS_DURATION = 12;   // seconds
+const RECONNECT_GRACE = 15;    // seconds
+const TOTAL_ROUNDS = 10;
 const MAX_CHAT_LENGTH = 300;
 
-// In-memory store of all rooms
-const rooms = new Map();
-
 // ---------------------------------------------------------------------------
-// Utility
+// In-memory state
 // ---------------------------------------------------------------------------
 
-function makeRoomCode() {
-  const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
-  let code;
-  do {
-    code = Array.from({ length: 6 }, () => chars[Math.floor(Math.random() * chars.length)]).join('');
-  } while (rooms.has(code));
-  return code;
-}
+// Per-session state keyed by accountId.
+// Tracks the WebSocket, autoRequeue toggle, and opponent history.
+const sessionState = new Map(); // accountId -> { ws, autoRequeue, previousOpponents }
+
+// Active matches keyed by matchId.
+const activeMatches = new Map(); // matchId -> MatchState
+
+// Reverse lookup: accountId -> matchId for fast match retrieval.
+const playerMatchIndex = new Map(); // accountId -> matchId
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 function send(ws, obj) {
-  if (ws && ws.readyState === 1 /* OPEN */) {
-    ws.send(JSON.stringify(obj));
+  if (ws?.readyState === 1) ws.send(JSON.stringify(obj));
+}
+
+function broadcastMatch(match, obj, excludeId = null) {
+  for (const [id, p] of match.players) {
+    if (id !== excludeId && p.ws) send(p.ws, obj);
   }
 }
 
-function broadcast(room, obj, excludeUsername = null) {
-  for (const [username, player] of room.players) {
-    if (username !== excludeUsername) {
-      send(player.ws, obj);
-    }
+function broadcastQueueState() {
+  for (const ws of queue.getAllQueuedWs()) {
+    const accountId = ws._accountId;
+    const session = sessionState.get(accountId);
+    const state = queue.getQueueState(accountId);
+    state.autoRequeue = session?.autoRequeue ?? false;
+    send(ws, state);
   }
 }
 
-function broadcastAll(room, obj) {
-  broadcast(room, obj, null);
+function getMatchForAccount(accountId) {
+  const matchId = playerMatchIndex.get(accountId);
+  if (!matchId) return null;
+  return activeMatches.get(matchId) || null;
 }
 
-function getPublicPlayers(room) {
-  return Array.from(room.players.values()).map(p => ({
-    username: p.username,
-    balance: p.balance,
-    isConnected: p.isConnected,
-    isHost: p.username === room.host,
-    hasCommitted: !!p.committed,
-    hasRevealed: !!p.revealed,
-  }));
-}
-
-function selectQuestions(totalRounds) {
-  const shuffled = [...QUESTIONS].sort(() => Math.random() - 0.5);
-  return shuffled.slice(0, totalRounds);
+function clearTimers(match) {
+  clearTimeout(match.commitTimer);
+  clearTimeout(match.revealTimer);
+  clearTimeout(match.resultsTimer);
+  match.commitTimer = null;
+  match.revealTimer = null;
+  match.resultsTimer = null;
 }
 
 // ---------------------------------------------------------------------------
-// Phase management
+// Message dispatch
 // ---------------------------------------------------------------------------
 
-function startCommitPhase(room) {
-  room.phase = 'commit';
-  clearTimers(room);
-
-  const question = room.questions[room.currentRound];
-  const isEstimation = question.category === 'estimation';
-  const commitDuration = isEstimation ? COMMIT_DURATION_ESTIMATION : COMMIT_DURATION_NORMAL;
-
-  // Reset per-round player state
-  for (const p of room.players.values()) {
-    p.committed = false;
-    p.revealed = false;
-    p.score = null;
-    p.hash = null;
-    p.salt = null;
-  }
-  room.leakReports = [];
-
-  broadcastAll(room, {
-    type: 'round_start',
-    round: room.currentRound + 1,
-    question,
-    commitDuration,
-    phase: 'commit',
-  });
-
-  room.commitTimer = setTimeout(() => startRevealPhase(room), commitDuration * 1000);
-}
-
-function startRevealPhase(room) {
-  clearTimers(room);
-  room.phase = 'reveal';
-
-  broadcastAll(room, {
-    type: 'phase_change',
-    phase: 'reveal',
-    revealDuration: REVEAL_DURATION,
-  });
-
-  room.revealTimer = setTimeout(() => finaliseRound(room), REVEAL_DURATION * 1000);
-}
-
-function finaliseRound(room) {
-  clearTimers(room);
-  room.phase = 'results';
-
-  const question = room.questions[room.currentRound];
-  const playerDataForLogic = Array.from(room.players.values()).map(p => ({
-    username: p.username,
-    score: p.score,
-    balance: p.balance,
-    stake: Math.min(ROUND_STAKE, p.balance > 0 ? p.balance : 0),
-    hash: p.hash,
-    committed: p.committed,
-    revealed: p.revealed,
-  }));
-
-  const result = computeRoundResult(
-    playerDataForLogic,
-    room.leakReports,
-    room.chatMessages,
-    room.currentRound,
-  );
-
-  // Apply balance changes
-  if (!result.cancelled) {
-    const changes = applyBalanceChanges(
-      Array.from(room.players.values()),
-      result,
-    );
-    for (const { username, newBalance } of changes) {
-      const p = room.players.get(username);
-      if (p) p.balance = newBalance;
-    }
-    // Annotate result players with new balance
-    for (const pr of result.players) {
-      const p = room.players.get(pr.username);
-      if (p) pr.newBalance = p.balance;
-    }
-  } else {
-    for (const pr of result.players) {
-      const p = room.players.get(pr.username);
-      if (p) pr.newBalance = p.balance;
-    }
-  }
-
-  result.roundNum = room.currentRound + 1;
-
-  // Log to DB
-  const playerCount = room.players.size;
-  for (const pr of result.players) {
-    db.insertVoteLog({
-      sessionId: room.sessionId,
-      roundNumber: room.currentRound + 1,
-      questionId: question.id,
-      username: pr.username,
-      revealedScore: pr.score,
-      mu: result.mu,
-      sigma: result.sigma,
-      isCoherent: pr.coherent,
-      slashAmount: pr.slash,
-      rewardAmount: pr.reward,
-      isLeaker: pr.isLeaker,
-      playerCount,
-    });
-  }
-
-  broadcastAll(room, { type: 'round_result', result });
-
-  // Advance after results display
-  room.resultsTimer = setTimeout(() => {
-    room.currentRound++;
-    if (room.currentRound >= room.totalRounds) {
-      endGame(room);
-    } else {
-      startCommitPhase(room);
-    }
-  }, RESULTS_DURATION * 1000);
-}
-
-function endGame(room) {
-  clearTimers(room);
-  room.phase = 'lobby';
-
-  const summary = {
-    players: Array.from(room.players.values()).map(p => ({
-      username: p.username,
-      finalBalance: p.balance,
-      profit: p.balance - STARTING_BALANCE,
-    })).sort((a, b) => b.finalBalance - a.finalBalance),
-  };
-
-  // Update global DB stats
-  for (const p of room.players.values()) {
-    db.updatePlayerStats(p.username, {
-      roundsPlayed: room.totalRounds,
-      coherentRounds: p.coherentRoundsThisGame || 0,
-      scoreChange: p.balance - STARTING_BALANCE,
-    });
-    p.coherentRoundsThisGame = 0;
-  }
-
-  broadcastAll(room, { type: 'game_over', summary });
-
-  // Reset room for potential replay
-  room.currentRound = 0;
-  room.questions = [];
-}
-
-function clearTimers(room) {
-  clearTimeout(room.commitTimer);
-  clearTimeout(room.revealTimer);
-  clearTimeout(room.resultsTimer);
-}
-
-// ---------------------------------------------------------------------------
-// Public API
-// ---------------------------------------------------------------------------
-
-/**
- * Handle a newly connected WebSocket. Returns the room code if joined.
- */
 function handleMessage(ws, rawData) {
   let msg;
   try {
     msg = JSON.parse(rawData);
   } catch {
-    send(ws, { type: 'error', message: 'Invalid JSON' });
-    return;
+    return send(ws, { type: 'error', message: 'Invalid JSON' });
   }
 
   switch (msg.type) {
-    case 'join':       return handleJoin(ws, msg);
-    case 'start_game': return handleStartGame(ws);
-    case 'commit':     return handleCommit(ws, msg);
-    case 'reveal':     return handleReveal(ws, msg);
-    case 'chat':       return handleChat(ws, msg);
-    case 'report_leak': return handleReportLeak(ws, msg);
+    case 'join_queue':  return handleJoinQueue(ws);
+    case 'leave_queue': return handleLeaveQueue(ws);
+    case 'commit':      return handleCommit(ws, msg);
+    case 'reveal':      return handleReveal(ws, msg);
+    case 'chat':        return handleChat(ws, msg);
     default:
       send(ws, { type: 'error', message: `Unknown message type: ${msg.type}` });
   }
 }
 
-function handleJoin(ws, msg) {
-  const { username, roomCode, roundCount } = msg;
-  if (!username || !roomCode) {
-    return send(ws, { type: 'error', message: 'username and roomCode required' });
-  }
-  if (!/^[A-Za-z0-9_\-]{1,20}$/.test(username)) {
-    return send(ws, { type: 'error', message: 'Username must be 1-20 characters (letters, digits, _ or -)' });
-  }
-  const code = roomCode.toUpperCase();
+// ---------------------------------------------------------------------------
+// Queue handlers
+// ---------------------------------------------------------------------------
 
-  db.upsertPlayer(username);
-
-  let room = rooms.get(code);
-  if (!room) {
-    // Create new room
-    room = {
-      code,
-      host: username,
-      players: new Map(),
-      phase: 'lobby',
-      currentRound: 0,
-      totalRounds: [5, 7, 10].includes(roundCount) ? roundCount : 10,
-      questions: [],
-      chatMessages: [],
-      leakReports: [],
-      commitTimer: null,
-      revealTimer: null,
-      resultsTimer: null,
-      sessionId: uuidv4(),
-    };
-    rooms.set(code, room);
+function handleJoinQueue(ws) {
+  const accountId = ws._accountId;
+  if (!accountId) {
+    return send(ws, { type: 'error', message: 'Not authenticated' });
   }
 
-  // Reconnect existing player or add new one
-  let player = room.players.get(username);
-  if (player) {
-    player.ws = ws;
-    player.isConnected = true;
+  const account = db.getAccount(accountId);
+  if (!account?.display_name) {
+    return send(ws, { type: 'error', message: 'Display name required before queueing' });
+  }
+
+  // Ensure session state exists
+  let session = sessionState.get(accountId);
+  if (!session) {
+    session = { ws, autoRequeue: true, previousOpponents: new Set() };
+    sessionState.set(accountId, session);
   } else {
-    if (room.phase !== 'lobby') {
-      return send(ws, { type: 'error', message: 'Game already in progress' });
-    }
-    player = {
-      username,
-      ws,
-      balance: STARTING_BALANCE,
-      committed: false,
-      revealed: false,
-      score: null,
-      hash: null,
-      salt: null,
-      stake: 0,
-      isConnected: true,
-      coherentRoundsThisGame: 0,
-    };
-    room.players.set(username, player);
+    session.ws = ws;
+    session.autoRequeue = true;
   }
 
-  // Tag ws with room and username for disconnect tracking
-  ws._roomCode = code;
-  ws._username = username;
-
-  send(ws, {
-    type: 'room_state',
-    room: {
-      code,
-      host: room.host,
-      phase: room.phase,
-      currentRound: room.currentRound,
-      totalRounds: room.totalRounds,
-    },
-    players: getPublicPlayers(room),
-    myBalance: player.balance,
+  const result = queue.enqueue({
+    accountId,
+    displayName: account.display_name,
+    ws,
+    previousOpponents: session.previousOpponents,
   });
 
-  // Broadcast updated player list
-  broadcast(room, {
-    type: 'room_state',
-    room: {
-      code,
-      host: room.host,
-      phase: room.phase,
-      currentRound: room.currentRound,
-      totalRounds: room.totalRounds,
-    },
-    players: getPublicPlayers(room),
-  }, username);
-}
-
-function handleStartGame(ws) {
-  const room = getRoomForWs(ws);
-  if (!room) return send(ws, { type: 'error', message: 'Not in a room' });
-  if (ws._username !== room.host) return send(ws, { type: 'error', message: 'Only the host can start the game' });
-  if (room.phase !== 'lobby') return send(ws, { type: 'error', message: 'Game already started' });
-  if (room.players.size < 1) return send(ws, { type: 'error', message: 'Need at least 1 player' });
-
-  room.questions = selectQuestions(room.totalRounds);
-  room.currentRound = 0;
-
-  // Reset balances
-  for (const p of room.players.values()) {
-    p.balance = STARTING_BALANCE;
-    p.coherentRoundsThisGame = 0;
+  if (!result.success) {
+    return send(ws, { type: 'error', message: result.error });
   }
 
-  broadcastAll(room, {
-    type: 'game_started',
-    roundCount: room.totalRounds,
-    firstRound: {
-      round: 1,
-      question: room.questions[0],
-    },
-  });
-
-  startCommitPhase(room);
+  broadcastQueueState();
 }
+
+function handleLeaveQueue(ws) {
+  const accountId = ws._accountId;
+  if (!accountId) return;
+
+  queue.dequeue(accountId);
+
+  const session = sessionState.get(accountId);
+  if (session) {
+    session.autoRequeue = false;
+  }
+
+  broadcastQueueState();
+}
+
+// ---------------------------------------------------------------------------
+// Commit handler
+// ---------------------------------------------------------------------------
 
 function handleCommit(ws, msg) {
-  const room = getRoomForWs(ws);
-  if (!room) return send(ws, { type: 'error', message: 'Not in a room' });
-  if (room.phase !== 'commit') return send(ws, { type: 'error', message: 'Not in commit phase' });
+  const accountId = ws._accountId;
+  if (!accountId) return send(ws, { type: 'error', message: 'Not authenticated' });
+
+  const match = getMatchForAccount(accountId);
+  if (!match) return send(ws, { type: 'error', message: 'Not in a match' });
+  if (match.phase !== 'commit') return send(ws, { type: 'error', message: 'Not in commit phase' });
+
+  const player = match.players.get(accountId);
+  if (!player) return send(ws, { type: 'error', message: 'Player not found in match' });
+  if (player.forfeited) return send(ws, { type: 'error', message: 'Forfeited players cannot act' });
+  if (player.committed) return send(ws, { type: 'error', message: 'Already committed' });
 
   const { hash } = msg;
-  if (typeof hash !== 'string' || !/^[0-9a-f]{64}$/.test(hash)) {
-    return send(ws, { type: 'error', message: 'Invalid hash format (expected 64-char hex)' });
+  if (!validateHash(hash)) {
+    return send(ws, { type: 'error', message: 'Invalid hash format (expected 64-char lowercase hex)' });
   }
-
-  const player = room.players.get(ws._username);
-  if (!player) return send(ws, { type: 'error', message: 'Player not found' });
-  if (player.committed) return send(ws, { type: 'error', message: 'Already committed' });
 
   player.committed = true;
   player.hash = hash;
 
-  // Broadcast commit status
-  broadcastAll(room, {
+  // Broadcast commit status using displayName per spec
+  broadcastMatch(match, {
     type: 'commit_status',
-    committed: Array.from(room.players.values()).map(p => ({
-      username: p.username,
+    committed: Array.from(match.players.values()).map(p => ({
+      displayName: p.displayName,
       hasCommitted: p.committed,
     })),
   });
 
-  // Auto-advance if all players committed
-  const allCommitted = Array.from(room.players.values()).every(p => p.committed);
-  if (allCommitted) {
-    clearTimeout(room.commitTimer);
-    startRevealPhase(room);
+  // Auto-advance: check if all non-forfeited, connected players have committed
+  const eligible = Array.from(match.players.values()).filter(
+    p => !p.forfeited && p.disconnectedAt === null
+  );
+  if (eligible.length > 0 && eligible.every(p => p.committed)) {
+    clearTimeout(match.commitTimer);
+    match.commitTimer = null;
+    startRevealPhase(match);
   }
 }
 
+// ---------------------------------------------------------------------------
+// Reveal handler
+// ---------------------------------------------------------------------------
+
 function handleReveal(ws, msg) {
-  const room = getRoomForWs(ws);
-  if (!room) return send(ws, { type: 'error', message: 'Not in a room' });
-  if (room.phase !== 'reveal') return send(ws, { type: 'error', message: 'Not in reveal phase' });
+  const accountId = ws._accountId;
+  if (!accountId) return send(ws, { type: 'error', message: 'Not authenticated' });
 
-  const { score, salt } = msg;
-  if (typeof score !== 'number' || score < 0 || score > 1) {
-    return send(ws, { type: 'error', message: 'score must be a number in [0,1]' });
-  }
-  if (typeof salt !== 'string' || !/^[0-9a-f]+$/.test(salt)) {
-    return send(ws, { type: 'error', message: 'salt must be a hex string' });
-  }
+  const match = getMatchForAccount(accountId);
+  if (!match) return send(ws, { type: 'error', message: 'Not in a match' });
+  if (match.phase !== 'reveal') return send(ws, { type: 'error', message: 'Not in reveal phase' });
 
-  const player = room.players.get(ws._username);
-  if (!player) return send(ws, { type: 'error', message: 'Player not found' });
-  if (!player.committed) return send(ws, { type: 'error', message: 'Did not commit' });
+  const player = match.players.get(accountId);
+  if (!player) return send(ws, { type: 'error', message: 'Player not found in match' });
+  if (player.forfeited) return send(ws, { type: 'error', message: 'Forfeited players cannot act' });
+  if (!player.committed) return send(ws, { type: 'error', message: 'Did not commit this round' });
   if (player.revealed) return send(ws, { type: 'error', message: 'Already revealed' });
 
-  // Verify hash
-  if (!verifyCommit(score, salt, player.hash)) {
-    return send(ws, { type: 'error', message: 'Hash mismatch — reveal does not match commitment' });
+  const { optionIndex, salt } = msg;
+
+  // Validate optionIndex
+  const question = match.questions[match.currentRound];
+  if (!validateOptionIndex(optionIndex, question.options.length)) {
+    return send(ws, { type: 'error', message: 'Invalid optionIndex: must be an integer within question options range' });
+  }
+
+  // Validate salt
+  if (!validateSalt(salt)) {
+    return send(ws, { type: 'error', message: 'Invalid salt: must be hex string of at least 32 characters' });
+  }
+
+  // Verify commitment hash
+  if (!verifyCommit(optionIndex, salt, player.hash)) {
+    return send(ws, { type: 'error', message: 'Hash mismatch: reveal does not match commitment' });
   }
 
   player.revealed = true;
-  player.score = Math.round(score * 100) / 100;
+  player.optionIndex = optionIndex;
   player.salt = salt;
 
   // Broadcast reveal status
-  broadcastAll(room, {
+  broadcastMatch(match, {
     type: 'reveal_status',
-    revealed: Array.from(room.players.values()).map(p => ({
-      username: p.username,
+    revealed: Array.from(match.players.values()).map(p => ({
+      displayName: p.displayName,
       hasRevealed: p.revealed,
     })),
   });
 
-  // Auto-advance if all committed players have revealed
-  const committedPlayers = Array.from(room.players.values()).filter(p => p.committed);
-  const allRevealed = committedPlayers.length > 0 && committedPlayers.every(p => p.revealed);
-  if (allRevealed) {
-    clearTimeout(room.revealTimer);
-    finaliseRound(room);
+  // Auto-advance: check if all committed, non-forfeited players have revealed
+  const mustReveal = Array.from(match.players.values()).filter(
+    p => p.committed && !p.forfeited
+  );
+  if (mustReveal.length > 0 && mustReveal.every(p => p.revealed)) {
+    clearTimeout(match.revealTimer);
+    match.revealTimer = null;
+    finalizeRound(match);
   }
 }
 
+// ---------------------------------------------------------------------------
+// Chat handler
+// ---------------------------------------------------------------------------
+
 function handleChat(ws, msg) {
-  const room = getRoomForWs(ws);
-  if (!room) return send(ws, { type: 'error', message: 'Not in a room' });
-  if (room.phase !== 'commit' && room.phase !== 'lobby') {
-    return send(ws, { type: 'error', message: 'Chat only allowed in lobby or commit phase' });
+  const accountId = ws._accountId;
+  if (!accountId) return send(ws, { type: 'error', message: 'Not authenticated' });
+
+  const match = getMatchForAccount(accountId);
+  if (!match) return send(ws, { type: 'error', message: 'Not in a match' });
+  if (match.phase !== 'commit') {
+    return send(ws, { type: 'error', message: 'Chat only allowed during commit phase' });
   }
+
+  const player = match.players.get(accountId);
+  if (!player) return;
+  if (player.forfeited) return send(ws, { type: 'error', message: 'Forfeited players cannot chat' });
 
   const text = String(msg.text || '').trim().slice(0, MAX_CHAT_LENGTH);
   if (!text) return;
 
-  const messageId = uuidv4();
-  const chatMsg = { id: messageId, username: ws._username, text, timestamp: Date.now() };
-  room.chatMessages.push(chatMsg);
-
-  broadcastAll(room, {
+  const messageId = `msg_${uuidv4()}`;
+  broadcastMatch(match, {
     type: 'chat',
-    from: ws._username,
+    from: player.displayName,
     text,
     messageId,
   });
 }
 
-function handleReportLeak(ws, msg) {
-  const room = getRoomForWs(ws);
-  if (!room) return send(ws, { type: 'error', message: 'Not in a room' });
-
-  const { messageId, suspectUsername } = msg;
-  if (!messageId || !suspectUsername) {
-    return send(ws, { type: 'error', message: 'messageId and suspectUsername required' });
-  }
-  if (suspectUsername === ws._username) {
-    return send(ws, { type: 'error', message: 'Cannot report yourself' });
-  }
-
-  // Deduplicate reports
-  const alreadyReported = room.leakReports.some(
-    r => r.messageId === messageId && r.reporterUsername === ws._username
-  );
-  if (!alreadyReported) {
-    room.leakReports.push({
-      messageId,
-      reporterUsername: ws._username,
-      suspectUsername,
-    });
-  }
-
-  send(ws, { type: 'report_ack', messageId });
-}
+// ---------------------------------------------------------------------------
+// Disconnect and reconnect
+// ---------------------------------------------------------------------------
 
 function handleDisconnect(ws) {
-  const { _roomCode, _username } = ws;
-  if (!_roomCode || !_username) return;
-  const room = rooms.get(_roomCode);
-  if (!room) return;
+  const accountId = ws._accountId;
+  if (!accountId) return;
 
-  const player = room.players.get(_username);
-  if (player) {
-    player.isConnected = false;
+  // If in queue, remove immediately
+  if (queue.isQueued(accountId)) {
+    queue.dequeue(accountId);
+    broadcastQueueState();
+  }
 
-    // If the game is in progress, apply a leave penalty (3 incoherent rounds)
-    let leavePenalty = 0;
-    if (room.phase !== 'lobby') {
-      leavePenalty = computeLeavePenalty(player.balance);
-      player.balance = Math.max(0, Math.round((player.balance - leavePenalty) * 100) / 100);
+  // If in active match, start grace timer
+  const match = getMatchForAccount(accountId);
+  if (match) {
+    const player = match.players.get(accountId);
+    if (player && !player.forfeited) {
+      player.disconnectedAt = Date.now();
+      player.ws = null;
+
+      // Notify other players
+      broadcastMatch(match, {
+        type: 'player_disconnected',
+        displayName: player.displayName,
+        graceSeconds: RECONNECT_GRACE,
+      });
+
+      // Start grace timer
+      player.graceTimer = setTimeout(() => {
+        // Still disconnected after grace period: forfeit
+        if (player.disconnectedAt !== null) {
+          player.forfeited = true;
+
+          broadcastMatch(match, {
+            type: 'player_forfeited',
+            displayName: player.displayName,
+            autoLosesRemainingRounds: true,
+          });
+
+          // Check if this forfeit triggers phase advancement
+          checkAutoAdvance(match);
+        }
+      }, RECONNECT_GRACE * 1000);
     }
+  }
+}
 
-    // Notify all remaining players that this player left
-    broadcastAll(room, {
-      type: 'player_left',
-      username: _username,
-      leavePenalty,
-      newBalance: player.balance,
+function handleReconnect(ws, accountId) {
+  // Update session state ws reference
+  const session = sessionState.get(accountId);
+  if (session) {
+    session.ws = ws;
+  }
+
+  // Update queue ws reference if still queued
+  queue.updatePlayerWs(accountId, ws);
+
+  // If in active match, reattach
+  const match = getMatchForAccount(accountId);
+  if (match) {
+    const player = match.players.get(accountId);
+    if (player) {
+      player.ws = ws;
+      player.disconnectedAt = null;
+
+      // Clear grace timer
+      if (player.graceTimer) {
+        clearTimeout(player.graceTimer);
+        player.graceTimer = null;
+      }
+
+      // Notify other players
+      broadcastMatch(match, {
+        type: 'player_reconnected',
+        displayName: player.displayName,
+      }, accountId);
+
+      // Send current match state to the reconnecting player
+      sendMatchStateCatchup(ws, match, accountId);
+    }
+  }
+}
+
+function sendMatchStateCatchup(ws, match, accountId) {
+  const question = match.questions[match.currentRound];
+  const player = match.players.get(accountId);
+
+  // Send game_started so client knows match context
+  send(ws, {
+    type: 'game_started',
+    matchId: match.matchId,
+    roundCount: match.totalRounds,
+    players: Array.from(match.players.values()).map(p => ({
+      displayName: p.displayName,
+      startingBalance: p.startingBalance,
+    })),
+  });
+
+  // Send current round info
+  send(ws, {
+    type: 'round_start',
+    round: match.currentRound + 1,
+    question,
+    commitDuration: COMMIT_DURATION,
+    roundAnte: ROUND_ANTE,
+    phase: match.phase,
+  });
+
+  // Send phase info if in reveal or results
+  if (match.phase === 'reveal') {
+    send(ws, {
+      type: 'phase_change',
+      phase: 'reveal',
+      revealDuration: REVEAL_DURATION,
     });
+  }
 
-    broadcastAll(room, {
-      type: 'room_state',
-      room: {
-        code: room.code,
-        host: room.host,
-        phase: room.phase,
-        currentRound: room.currentRound,
-        totalRounds: room.totalRounds,
-      },
-      players: getPublicPlayers(room),
+  // Send commit status
+  send(ws, {
+    type: 'commit_status',
+    committed: Array.from(match.players.values()).map(p => ({
+      displayName: p.displayName,
+      hasCommitted: p.committed,
+    })),
+  });
+
+  // Send reveal status if in reveal phase
+  if (match.phase === 'reveal' || match.phase === 'results') {
+    send(ws, {
+      type: 'reveal_status',
+      revealed: Array.from(match.players.values()).map(p => ({
+        displayName: p.displayName,
+        hasRevealed: p.revealed,
+      })),
     });
   }
 }
 
-function getRoomForWs(ws) {
-  return ws._roomCode ? rooms.get(ws._roomCode) : null;
+/**
+ * After a forfeit or disconnect, check whether the current phase
+ * can auto-advance because all remaining eligible players have acted.
+ */
+function checkAutoAdvance(match) {
+  if (match.phase === 'commit') {
+    const eligible = Array.from(match.players.values()).filter(
+      p => !p.forfeited && p.disconnectedAt === null
+    );
+    if (eligible.length > 0 && eligible.every(p => p.committed)) {
+      clearTimeout(match.commitTimer);
+      match.commitTimer = null;
+      startRevealPhase(match);
+    }
+  } else if (match.phase === 'reveal') {
+    const mustReveal = Array.from(match.players.values()).filter(
+      p => p.committed && !p.forfeited
+    );
+    if (mustReveal.length > 0 && mustReveal.every(p => p.revealed)) {
+      clearTimeout(match.revealTimer);
+      match.revealTimer = null;
+      finalizeRound(match);
+    }
+  }
 }
 
-export { handleMessage, handleDisconnect, rooms };
+// ---------------------------------------------------------------------------
+// Match lifecycle
+// ---------------------------------------------------------------------------
+
+/**
+ * Called by the matchmaking queue when a match is ready.
+ * players: array of { accountId, displayName, ws, previousOpponents }
+ */
+function onMatchReady(players, matchId) {
+  // Load balances and create DB records
+  db.createMatch({ matchId, playerCount: players.length });
+
+  const questions = selectQuestionsForMatch(TOTAL_ROUNDS);
+
+  const playerMap = new Map();
+  for (const p of players) {
+    const account = db.getAccount(p.accountId);
+    const startingBalance = account?.token_balance ?? 0;
+
+    db.addMatchPlayer({
+      matchId,
+      accountId: p.accountId,
+      displayNameSnapshot: p.displayName,
+      startingBalance,
+    });
+
+    playerMap.set(p.accountId, {
+      accountId: p.accountId,
+      displayName: p.displayName,
+      ws: p.ws,
+      startingBalance,
+      committed: false,
+      revealed: false,
+      hash: null,
+      optionIndex: null,
+      salt: null,
+      forfeited: false,
+      disconnectedAt: null,
+      graceTimer: null,
+    });
+
+    // Register the reverse lookup
+    playerMatchIndex.set(p.accountId, matchId);
+
+    // Update previous opponents for anti-repeat matchmaking
+    const session = sessionState.get(p.accountId);
+    if (session) {
+      session.previousOpponents = new Set(
+        players.filter(x => x.accountId !== p.accountId).map(x => x.accountId)
+      );
+    }
+  }
+
+  const match = {
+    matchId,
+    players: playerMap,
+    questions,
+    currentRound: 0,
+    totalRounds: TOTAL_ROUNDS,
+    phase: 'commit',
+    commitTimer: null,
+    revealTimer: null,
+    resultsTimer: null,
+  };
+
+  activeMatches.set(matchId, match);
+  queue.registerActiveMatch(matchId, match);
+
+  // Broadcast game_started
+  broadcastMatch(match, {
+    type: 'game_started',
+    matchId,
+    roundCount: TOTAL_ROUNDS,
+    players: Array.from(playerMap.values()).map(p => ({
+      displayName: p.displayName,
+      startingBalance: p.startingBalance,
+    })),
+  });
+
+  startCommitPhase(match);
+}
+
+function startCommitPhase(match) {
+  match.phase = 'commit';
+
+  const question = match.questions[match.currentRound];
+
+  // Reset per-round player state
+  for (const p of match.players.values()) {
+    p.committed = false;
+    p.revealed = false;
+    p.hash = null;
+    p.optionIndex = null;
+    p.salt = null;
+  }
+
+  broadcastMatch(match, {
+    type: 'round_start',
+    round: match.currentRound + 1,
+    question,
+    commitDuration: COMMIT_DURATION,
+    roundAnte: ROUND_ANTE,
+    phase: 'commit',
+  });
+
+  match.commitTimer = setTimeout(() => {
+    match.commitTimer = null;
+    startRevealPhase(match);
+  }, COMMIT_DURATION * 1000);
+}
+
+function startRevealPhase(match) {
+  match.phase = 'reveal';
+
+  broadcastMatch(match, {
+    type: 'phase_change',
+    phase: 'reveal',
+    revealDuration: REVEAL_DURATION,
+  });
+
+  match.revealTimer = setTimeout(() => {
+    match.revealTimer = null;
+    finalizeRound(match);
+  }, REVEAL_DURATION * 1000);
+}
+
+function finalizeRound(match) {
+  clearTimers(match);
+  match.phase = 'results';
+
+  const question = match.questions[match.currentRound];
+
+  // Build the player input array for settleRound.
+  // "attached" means the player is still part of the match for accounting.
+  // All players remain attached; forfeited players simply have no valid reveal.
+  const settleInput = Array.from(match.players.values()).map(p => ({
+    accountId: p.accountId,
+    displayName: p.displayName,
+    optionIndex: p.optionIndex,
+    validReveal: p.committed && p.revealed && !p.forfeited,
+    forfeited: p.forfeited,
+    attached: true, // all players remain attached for pot calculation
+  }));
+
+  const result = settleRound(settleInput, question);
+  result.roundNum = match.currentRound + 1;
+
+  // Apply balance deltas to DB and annotate results with newBalance
+  for (const pr of result.players) {
+    if (pr.netDelta !== 0) {
+      db.updateBalance(pr.accountId, pr.netDelta);
+    }
+    const updatedAccount = db.getAccount(pr.accountId);
+    pr.newBalance = updatedAccount?.token_balance ?? 0;
+  }
+
+  // Log vote records
+  for (const pr of result.players) {
+    db.insertVoteLog({
+      matchId: match.matchId,
+      roundNumber: match.currentRound + 1,
+      questionId: question.id,
+      accountId: pr.accountId,
+      displayNameSnapshot: pr.displayName,
+      revealedOptionIndex: pr.revealedOptionIndex,
+      revealedOptionLabel: pr.revealedOptionLabel,
+      wonRound: pr.wonRound,
+      earnsCoordinationCredit: pr.earnsCoordinationCredit,
+      anteAmount: pr.antePaid,
+      roundPayout: pr.roundPayout,
+      netDelta: pr.netDelta,
+      playerCount: result.playerCount,
+      validRevealCount: result.validRevealCount,
+      topCount: result.topCount,
+      winnerCount: result.winnerCount,
+      winningOptionIndexesJson: JSON.stringify(result.winningOptionIndexes),
+      voided: result.voided,
+      voidReason: result.voidReason,
+    });
+  }
+
+  // Update per-round player stats
+  for (const pr of result.players) {
+    if (!result.voided) {
+      db.updatePlayerStats(pr.accountId, {
+        roundsPlayed: 1,
+        coherentRounds: pr.earnsCoordinationCredit ? 1 : 0,
+        isGameEnd: false,
+        wonRound: pr.wonRound,
+        earnsCoordinationCredit: pr.earnsCoordinationCredit,
+      });
+    }
+  }
+
+  broadcastMatch(match, { type: 'round_result', result });
+
+  // Advance after results display
+  match.resultsTimer = setTimeout(() => {
+    match.resultsTimer = null;
+    match.currentRound++;
+    if (match.currentRound >= match.totalRounds || !hasNonForfeitedPlayers(match)) {
+      endMatch(match);
+    } else {
+      startCommitPhase(match);
+    }
+  }, RESULTS_DURATION * 1000);
+}
+
+function hasNonForfeitedPlayers(match) {
+  for (const p of match.players.values()) {
+    if (!p.forfeited) return true;
+  }
+  return false;
+}
+
+function endMatch(match) {
+  clearTimers(match);
+
+  // Compute summary
+  const summary = {
+    players: Array.from(match.players.values()).map(p => {
+      const account = db.getAccount(p.accountId);
+      const endingBalance = account?.token_balance ?? 0;
+      const netDelta = endingBalance - p.startingBalance;
+      const result = p.forfeited ? 'forfeited' : 'completed';
+
+      // Update match_players in DB
+      db.updateMatchPlayer({
+        matchId: match.matchId,
+        accountId: p.accountId,
+        endingBalance,
+        netDelta,
+        result,
+      });
+
+      // Update games_played stat for game end
+      db.updatePlayerStats(p.accountId, {
+        roundsPlayed: 0,
+        coherentRounds: 0,
+        isGameEnd: true,
+        wonRound: false,
+        earnsCoordinationCredit: false,
+      });
+
+      return {
+        displayName: p.displayName,
+        startingBalance: p.startingBalance,
+        endingBalance,
+        netDelta,
+        result,
+      };
+    }).sort((a, b) => b.endingBalance - a.endingBalance),
+  };
+
+  db.endMatch(match.matchId);
+
+  broadcastMatch(match, { type: 'game_over', summary });
+
+  // Cleanup: remove match from indexes
+  queue.unregisterActiveMatch(match.matchId);
+  for (const [accountId, p] of match.players) {
+    playerMatchIndex.delete(accountId);
+
+    // Clear any lingering grace timers
+    if (p.graceTimer) {
+      clearTimeout(p.graceTimer);
+      p.graceTimer = null;
+    }
+  }
+  activeMatches.delete(match.matchId);
+
+  // Auto-requeue eligible players
+  for (const [accountId, p] of match.players) {
+    if (p.forfeited) continue;
+    const session = sessionState.get(accountId);
+    if (!session || !session.autoRequeue) continue;
+    if (!session.ws || session.ws.readyState !== 1) continue;
+
+    const account = db.getAccount(accountId);
+    if (!account?.display_name) continue;
+
+    queue.enqueue({
+      accountId,
+      displayName: account.display_name,
+      ws: session.ws,
+      previousOpponents: session.previousOpponents,
+    });
+  }
+
+  broadcastQueueState();
+}
+
+// ---------------------------------------------------------------------------
+// Account state for /api/me
+// ---------------------------------------------------------------------------
+
+function getAccountState(accountId) {
+  const session = sessionState.get(accountId);
+  const isQueued = queue.isQueued(accountId);
+  const inMatch = playerMatchIndex.has(accountId);
+
+  let queueStatus = 'idle';
+  if (inMatch) {
+    queueStatus = 'in_match';
+  } else if (isQueued) {
+    queueStatus = 'queued';
+  }
+
+  return {
+    autoRequeue: session?.autoRequeue ?? false,
+    queueStatus,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Wire up the matchmaking callback
+// ---------------------------------------------------------------------------
+
+queue.onMatchReady = (players, matchId) => onMatchReady(players, matchId);
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export {
+  handleMessage,
+  handleDisconnect,
+  handleReconnect,
+  getAccountState,
+  sessionState,
+  activeMatches,
+};

--- a/src/matchmaking.js
+++ b/src/matchmaking.js
@@ -1,0 +1,232 @@
+import { v4 as uuidv4 } from 'uuid';
+
+const FILL_TIMER_MS = 20_000; // 20 seconds
+const ALLOWED_SIZES = [3, 5, 7];
+const MAX_MATCH_SIZE = 7;
+
+class MatchmakingQueue {
+  constructor() {
+    this.waitingQueue = []; // Array of { accountId, displayName, ws, joinedAt, previousOpponents: Set }
+    this.formingMatch = null; // { players: [], timer, fillDeadlineMs, startedForming }
+    this.activeMatches = new Map(); // matchId -> Match state (managed by gameManager)
+    this.onMatchReady = null; // callback: (players, matchId) => void
+  }
+
+  /**
+   * Add a player to the queue.
+   * @param {{ accountId, displayName, ws, previousOpponents }} player
+   * @returns {{ success, error? }}
+   */
+  enqueue(player) {
+    // Check not already queued
+    if (this.isQueued(player.accountId)) {
+      return { success: false, error: 'Already queued' };
+    }
+    // Check not in active match
+    if (this.isInActiveMatch(player.accountId)) {
+      return { success: false, error: 'In active match' };
+    }
+
+    this.waitingQueue.push({
+      accountId: player.accountId,
+      displayName: player.displayName,
+      ws: player.ws,
+      joinedAt: Date.now(),
+      previousOpponents: player.previousOpponents || new Set(),
+    });
+
+    this._tryFormMatch();
+    return { success: true };
+  }
+
+  /**
+   * Remove a player from queue or forming match.
+   */
+  dequeue(accountId) {
+    // Remove from waiting queue
+    this.waitingQueue = this.waitingQueue.filter(p => p.accountId !== accountId);
+
+    // Remove from forming match
+    if (this.formingMatch) {
+      const idx = this.formingMatch.players.findIndex(p => p.accountId === accountId);
+      if (idx !== -1) {
+        this.formingMatch.players.splice(idx, 1);
+        // If below 3, cancel forming
+        if (this.formingMatch.players.length < 3) {
+          this._cancelForming();
+        }
+      }
+    }
+  }
+
+  isQueued(accountId) {
+    if (this.waitingQueue.some(p => p.accountId === accountId)) return true;
+    if (this.formingMatch?.players.some(p => p.accountId === accountId)) return true;
+    return false;
+  }
+
+  isInActiveMatch(accountId) {
+    for (const match of this.activeMatches.values()) {
+      if (match.players && match.players.some(p => p.accountId === accountId)) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Get current queue state for broadcasting.
+   */
+  getQueueState(forAccountId = null) {
+    const queuedPlayers = [
+      ...(this.formingMatch ? this.formingMatch.players : []),
+      ...this.waitingQueue,
+    ].map(p => p.displayName);
+
+    return {
+      type: 'queue_state',
+      status: this.formingMatch?.players.some(p => p.accountId === forAccountId) ? 'forming' :
+              this.waitingQueue.some(p => p.accountId === forAccountId) ? 'queued' : 'idle',
+      queuedCount: queuedPlayers.length,
+      queuedPlayers,
+      formingMatch: this.formingMatch ? {
+        playerCount: this.formingMatch.players.length,
+        players: this.formingMatch.players.map(p => p.displayName),
+        allowedSizes: ALLOWED_SIZES,
+        fillDeadlineMs: this.formingMatch.fillDeadlineMs,
+      } : null,
+    };
+  }
+
+  /**
+   * Get all WebSockets for queued players (for broadcasting).
+   */
+  getAllQueuedWs() {
+    const wsList = [];
+    if (this.formingMatch) {
+      for (const p of this.formingMatch.players) {
+        if (p.ws) wsList.push(p.ws);
+      }
+    }
+    for (const p of this.waitingQueue) {
+      if (p.ws) wsList.push(p.ws);
+    }
+    return wsList;
+  }
+
+  /**
+   * Register a match as active.
+   */
+  registerActiveMatch(matchId, matchState) {
+    this.activeMatches.set(matchId, matchState);
+  }
+
+  /**
+   * Unregister a completed match.
+   */
+  unregisterActiveMatch(matchId) {
+    this.activeMatches.delete(matchId);
+  }
+
+  /**
+   * Update a player's WebSocket reference (for reconnects).
+   */
+  updatePlayerWs(accountId, ws) {
+    const inQueue = this.waitingQueue.find(p => p.accountId === accountId);
+    if (inQueue) inQueue.ws = ws;
+    if (this.formingMatch) {
+      const inForming = this.formingMatch.players.find(p => p.accountId === accountId);
+      if (inForming) inForming.ws = ws;
+    }
+  }
+
+  // ---- Internal ----
+
+  _tryFormMatch() {
+    if (this.formingMatch) {
+      // Try to add more players to existing forming match
+      while (this.waitingQueue.length > 0 && this.formingMatch.players.length < MAX_MATCH_SIZE) {
+        const next = this.waitingQueue.shift();
+        this.formingMatch.players.push(next);
+      }
+      // If reached 7, start immediately
+      if (this.formingMatch.players.length >= MAX_MATCH_SIZE) {
+        this._startMatch();
+      }
+      return;
+    }
+
+    // Need at least 3 to start forming
+    if (this.waitingQueue.length < 3) return;
+
+    // Reserve first 3 players
+    const reserved = this.waitingQueue.splice(0, 3);
+
+    this.formingMatch = {
+      players: reserved,
+      fillDeadlineMs: Date.now() + FILL_TIMER_MS,
+      timer: setTimeout(() => this._onFillTimerExpired(), FILL_TIMER_MS),
+    };
+
+    // Try to add more
+    while (this.waitingQueue.length > 0 && this.formingMatch.players.length < MAX_MATCH_SIZE) {
+      const next = this.waitingQueue.shift();
+      this.formingMatch.players.push(next);
+    }
+
+    // If reached 7, start immediately
+    if (this.formingMatch.players.length >= MAX_MATCH_SIZE) {
+      this._startMatch();
+    }
+  }
+
+  _onFillTimerExpired() {
+    if (!this.formingMatch) return;
+    this._startMatch();
+  }
+
+  _startMatch() {
+    if (!this.formingMatch) return;
+    clearTimeout(this.formingMatch.timer);
+
+    const reserved = this.formingMatch.players;
+    // Find largest odd size <= reserved.length
+    let matchSize = 3;
+    for (const size of [7, 5, 3]) {
+      if (reserved.length >= size) {
+        matchSize = size;
+        break;
+      }
+    }
+
+    // Take matchSize players, push extras back to front of queue
+    const matchPlayers = reserved.slice(0, matchSize);
+    const extras = reserved.slice(matchSize);
+
+    // Return extras to front of queue in their existing order
+    this.waitingQueue.unshift(...extras);
+
+    this.formingMatch = null;
+
+    const matchId = `match_${uuidv4()}`;
+
+    if (this.onMatchReady) {
+      this.onMatchReady(matchPlayers, matchId);
+    }
+
+    // Try to form next match
+    this._tryFormMatch();
+  }
+
+  _cancelForming() {
+    if (!this.formingMatch) return;
+    clearTimeout(this.formingMatch.timer);
+    // Return all to front of queue
+    this.waitingQueue.unshift(...this.formingMatch.players);
+    this.formingMatch = null;
+    // Don't retry forming here since we just lost players
+  }
+}
+
+// Singleton
+const queue = new MatchmakingQueue();
+export default queue;
+export { MatchmakingQueue, FILL_TIMER_MS, ALLOWED_SIZES, MAX_MATCH_SIZE };

--- a/test/test.js
+++ b/test/test.js
@@ -1,333 +1,406 @@
 /**
- * Test suite for Schelling Game logic.
+ * Canonical test suite for Schelling Game plurality engine.
  * Run with: node test/test.js
  */
 
-import crypto from 'node:crypto';
-import { verifyCommit, computeRoundResult, applyBalanceChanges, extractNumbers, computeLeavePenalty } from '../src/gameLogic.js';
+import { createCommitHash, verifyCommit, validateSalt, validateHash, validateOptionIndex } from '../src/domain/commitReveal.js';
+import { settleRound, ROUND_ANTE } from '../src/domain/settlement.js';
+import { getPublicPool, selectQuestionsForMatch, validatePool } from '../src/domain/questions.js';
 
 let passed = 0;
 let failed = 0;
 
 function assert(condition, label) {
-  if (condition) {
-    console.log(`  ✓ ${label}`);
-    passed++;
-  } else {
-    console.error(`  ✗ ${label}`);
-    failed++;
-  }
+  if (condition) { console.log(`  + ${label}`); passed++; }
+  else { console.error(`  x ${label}`); failed++; }
 }
 
-function approx(a, b, eps = 0.001) {
-  return Math.abs(a - b) < eps;
+const question = { id: 1, text: 'Test', options: ['A', 'B', 'C', 'D'] };
+
+function makePlayer(id, name, optionIndex, validReveal = true, forfeited = false) {
+  return { accountId: id, displayName: name, optionIndex, validReveal, forfeited, attached: true };
 }
 
 // ---------------------------------------------------------------------------
-// Helper: build a SHA-256 commit the same way the server does
-// ---------------------------------------------------------------------------
-function makeCommit(score, salt) {
-  const preimage = `${score.toFixed(2)}:${salt}`;
-  return crypto.createHash('sha256').update(preimage).digest('hex');
-}
-
-// ---------------------------------------------------------------------------
-// 1. Commit-reveal verification
+// 1. Commit-Reveal Verification
 // ---------------------------------------------------------------------------
 console.log('\n1. Commit-Reveal Verification');
 
 {
-  const score = 0.75;
-  const salt = 'deadbeef1234';
-  const hash = makeCommit(score, salt);
+  const optionIndex = 2;
+  const salt = 'a'.repeat(32);
+  const hash = createCommitHash(optionIndex, salt);
 
-  assert(verifyCommit(score, salt, hash), 'Valid commit verifies correctly');
-  assert(!verifyCommit(0.74, salt, hash), 'Wrong score rejected');
-  assert(!verifyCommit(score, 'wrongsalt', hash), 'Wrong salt rejected');
-  assert(!verifyCommit(score, salt, 'a'.repeat(64)), 'Wrong hash rejected');
+  assert(verifyCommit(optionIndex, salt, hash), 'Valid commit verifies correctly');
+  assert(!verifyCommit(1, salt, hash), 'Wrong optionIndex rejected');
+  assert(!verifyCommit(optionIndex, 'b'.repeat(32), hash), 'Wrong salt rejected');
+  assert(!verifyCommit(optionIndex, salt, 'f'.repeat(64)), 'Wrong hash rejected');
 }
 
 {
-  const score = 0.00;
-  const salt = 'abc';
-  const hash = makeCommit(score, salt);
-  assert(verifyCommit(score, salt, hash), 'Score 0.00 verifies');
+  assert(!validateSalt('abcd'), 'Salt too short (< 32 hex chars) rejected');
+  assert(!validateSalt('z'.repeat(32)), 'Non-hex salt rejected');
+  assert(validateSalt('a'.repeat(32)), 'Valid salt (32 hex chars) accepted');
+  assert(validateSalt('abcdef0123456789'.repeat(3)), 'Valid salt (48 hex chars) accepted');
 }
 
 {
-  const score = 1.00;
-  const salt = 'xyz';
-  const hash = makeCommit(score, salt);
-  assert(verifyCommit(score, salt, hash), 'Score 1.00 verifies');
+  assert(validateHash('a'.repeat(64)), 'Valid hash (64 hex chars) accepted');
+  assert(!validateHash('a'.repeat(63)), 'Hash too short rejected');
+  assert(!validateHash('a'.repeat(65)), 'Hash too long rejected');
+  assert(!validateHash('g'.repeat(64)), 'Non-hex hash rejected');
+  assert(!validateHash(123), 'Non-string hash rejected');
+}
+
+{
+  assert(validateOptionIndex(0, 4), 'Option index 0 valid for 4 options');
+  assert(validateOptionIndex(3, 4), 'Option index 3 valid for 4 options');
+  assert(!validateOptionIndex(4, 4), 'Option index 4 out of range for 4 options');
+  assert(!validateOptionIndex(-1, 4), 'Negative option index rejected');
+  assert(!validateOptionIndex(1.5, 4), 'Non-integer option index rejected');
+  assert(!validateOptionIndex(NaN, 4), 'NaN option index rejected');
 }
 
 // ---------------------------------------------------------------------------
-// 2. extractNumbers
+// 2. Question Pool
 // ---------------------------------------------------------------------------
-console.log('\n2. extractNumbers');
-
-assert(JSON.stringify(extractNumbers('I think 0.75 or maybe 0.8')) === JSON.stringify([0.75, 0.8]),
-  'Extracts decimals from text');
-assert(JSON.stringify(extractNumbers('no numbers here')) === JSON.stringify([]),
-  'Returns empty for no numbers');
-assert(JSON.stringify(extractNumbers('balance is -5 or 10')) === JSON.stringify([-5, 10]),
-  'Handles negative numbers');
-
-// ---------------------------------------------------------------------------
-// 3. Scoring formulas — basic coherent round
-// ---------------------------------------------------------------------------
-console.log('\n3. Basic coherent round (3 players, all reveal)');
+console.log('\n2. Question Pool');
 
 {
-  // Use scores spread enough that sigma > 0.02, yet all within 1.25σ of mean
-  const salt = 'aabbcc';
+  const pool = getPublicPool();
+  assert(pool.length > 0, 'Pool is non-empty');
+  assert(pool.every(q => q.type === 'select'), 'All questions are select type');
+  assert(pool.every(q => Array.isArray(q.options) && q.options.length > 0), 'All questions have non-empty options array');
+  assert(validatePool(), 'validatePool returns true');
+}
+
+{
+  const selected = selectQuestionsForMatch(5);
+  assert(selected.length === 5, 'selectQuestionsForMatch returns correct count');
+
+  const ids = selected.map(q => q.id);
+  const uniqueIds = new Set(ids);
+  assert(uniqueIds.size === 5, 'Selected questions are unique (no duplicates)');
+}
+
+{
+  const pool = getPublicPool();
+  let threw = false;
+  try {
+    selectQuestionsForMatch(pool.length + 1);
+  } catch (e) {
+    threw = e instanceof RangeError;
+  }
+  assert(threw, 'Requesting more than pool size throws RangeError');
+}
+
+// ---------------------------------------------------------------------------
+// 3. Plurality Settlement: Basic Cases
+// ---------------------------------------------------------------------------
+console.log('\n3. Plurality Settlement: Basic Cases');
+
+// 3a. 3 players all pick same option
+{
   const players = [
-    { username: 'alice', score: 0.30, balance: 100, committed: true, revealed: true, hash: makeCommit(0.30, salt) },
-    { username: 'bob',   score: 0.50, balance: 100, committed: true, revealed: true, hash: makeCommit(0.50, salt) },
-    { username: 'carol', score: 0.70, balance: 100, committed: true, revealed: true, hash: makeCommit(0.70, salt) },
+    makePlayer('a1', 'Alice', 0),
+    makePlayer('a2', 'Bob', 0),
+    makePlayer('a3', 'Carol', 0),
   ];
+  const result = settleRound(players, question);
 
-  const result = computeRoundResult(players, [], [], 0);
-
-  assert(!result.cancelled, 'Round not cancelled');
-  assert(typeof result.mu === 'number', 'mu is a number');
-  assert(approx(result.mu, 0.50, 0.01), `mu ≈ 0.50 (got ${result.mu})`);
-  assert(result.sigma < 0.2, `sigma is moderate (got ${result.sigma})`);
-  assert(result.players.every(p => p.coherent), 'All players coherent');
-  assert(result.players.every(p => p.slash === 0), 'No slashing when all coherent');
-  assert(result.players.every(p => p.reward === 0), 'No rewards when no slashing');
+  assert(!result.voided, '3 same picks: round not voided');
+  assert(result.pot === 180, '3 same picks: pot = 180');
+  assert(result.winnerCount === 3, '3 same picks: all 3 win');
+  assert(result.payoutPerWinner === 60, '3 same picks: payout = 60 each');
+  assert(result.players.every(p => p.netDelta === 0), '3 same picks: net delta = 0 each');
+  assert(result.players.every(p => p.earnsCoordinationCredit), '3 same picks: all earn coordination credit');
 }
 
-// ---------------------------------------------------------------------------
-// 4. Incoherent player gets slashed
-// ---------------------------------------------------------------------------
-console.log('\n4. Incoherent player slashing');
-
+// 3b. 3 players: 2 pick A, 1 picks B
 {
-  const salt = 'ff00ff';
-  // alice, bob, carol cluster near 0.50; dave is a far outlier
   const players = [
-    { username: 'alice', score: 0.30, balance: 100, committed: true, revealed: true, hash: makeCommit(0.30, salt) },
-    { username: 'bob',   score: 0.50, balance: 100, committed: true, revealed: true, hash: makeCommit(0.50, salt) },
-    { username: 'carol', score: 0.60, balance: 100, committed: true, revealed: true, hash: makeCommit(0.60, salt) },
-    { username: 'dave',  score: 0.99, balance: 100, committed: true, revealed: true, hash: makeCommit(0.99, salt) },
+    makePlayer('a1', 'Alice', 0),
+    makePlayer('a2', 'Bob', 0),
+    makePlayer('a3', 'Carol', 1),
   ];
+  const result = settleRound(players, question);
 
-  const result = computeRoundResult(players, [], [], 1);
+  assert(!result.voided, '2-1 split: round not voided');
+  assert(result.topCount === 2, '2-1 split: topCount = 2');
+  assert(result.winnerCount === 2, '2-1 split: 2 winners');
+  assert(result.payoutPerWinner === 90, '2-1 split: payout = 90 each');
 
-  assert(!result.cancelled, 'Round not cancelled');
-  const dave = result.players.find(p => p.username === 'dave');
-  assert(dave && !dave.coherent, 'Dave is incoherent');
-  assert(dave && dave.slash > 0, `Dave slashed (got ${dave?.slash})`);
-  assert(dave && approx(dave.slash, 0.03 * 100, 0.01), `Dave slashed 3% of stake (got ${dave?.slash})`);
-
-  const coherentPlayers = result.players.filter(p => p.coherent);
-  assert(coherentPlayers.every(p => p.reward > 0), 'Coherent players receive rewards');
-  const totalRewards = coherentPlayers.reduce((s, p) => s + p.reward, 0);
-  assert(approx(totalRewards, dave.slash, 0.01), `Total rewards ≈ total slash (${totalRewards} vs ${dave.slash})`);
+  const carol = result.players.find(p => p.accountId === 'a3');
+  assert(carol && !carol.wonRound, '2-1 split: loser did not win');
+  assert(carol && carol.netDelta === -60, '2-1 split: loser net delta = -60');
+  assert(carol && !carol.earnsCoordinationCredit, '2-1 split: loser no coordination credit');
 }
 
-// ---------------------------------------------------------------------------
-// 5. Flat round cancellation (sigma < 0.02)
-// ---------------------------------------------------------------------------
-console.log('\n5. Flat round cancellation');
-
+// 3c. 5 players: 3-1-1 split
 {
-  const salt = '010203';
   const players = [
-    { username: 'alice', score: 0.50, balance: 100, committed: true, revealed: true, hash: makeCommit(0.50, salt) },
-    { username: 'bob',   score: 0.50, balance: 100, committed: true, revealed: true, hash: makeCommit(0.50, salt) },
-    { username: 'carol', score: 0.50, balance: 100, committed: true, revealed: true, hash: makeCommit(0.50, salt) },
+    makePlayer('a1', 'Alice', 0),
+    makePlayer('a2', 'Bob', 0),
+    makePlayer('a3', 'Carol', 0),
+    makePlayer('a4', 'Dave', 1),
+    makePlayer('a5', 'Eve', 2),
   ];
+  const result = settleRound(players, question);
 
-  const result = computeRoundResult(players, [], [], 2);
-  assert(result.cancelled, 'Round cancelled when sigma < 0.02');
-  assert(result.cancelReason === 'sigma_too_small', `Cancel reason correct (got ${result.cancelReason})`);
+  assert(result.topCount === 3, '3-1-1 split: topCount = 3');
+  assert(result.winnerCount === 3, '3-1-1 split: 3 winners');
+  assert(result.pot === 300, '3-1-1 split: pot = 300');
+  assert(result.payoutPerWinner === 100, '3-1-1 split: payout = 100 each');
+
+  const losers = result.players.filter(p => !p.wonRound);
+  assert(losers.length === 2, '3-1-1 split: 2 losers');
+  assert(losers.every(p => p.netDelta === -60), '3-1-1 split: losers net delta = -60');
 }
 
-// ---------------------------------------------------------------------------
-// 6. Fewer than 2 reveals — round cancelled
-// ---------------------------------------------------------------------------
-console.log('\n6. Fewer than 2 reveals → cancelled');
-
+// 3d. 7 players: 4-2-1 split
 {
-  const salt = 'aaa';
   const players = [
-    { username: 'alice', score: 0.50, balance: 100, committed: true, revealed: true, hash: makeCommit(0.50, salt) },
-    // bob and carol did not reveal
-    { username: 'bob',   score: null, balance: 100, committed: false, revealed: false, hash: null },
-    { username: 'carol', score: null, balance: 100, committed: false, revealed: false, hash: null },
+    makePlayer('a1', 'Alice', 0),
+    makePlayer('a2', 'Bob', 0),
+    makePlayer('a3', 'Carol', 0),
+    makePlayer('a4', 'Dave', 0),
+    makePlayer('a5', 'Eve', 1),
+    makePlayer('a6', 'Frank', 1),
+    makePlayer('a7', 'Grace', 2),
   ];
+  const result = settleRound(players, question);
 
-  const result = computeRoundResult(players, [], [], 3);
-  assert(result.cancelled, 'Round cancelled with only 1 reveal');
-  assert(result.cancelReason === 'fewer_than_2_reveals', `Cancel reason correct (got ${result.cancelReason})`);
+  assert(result.topCount === 4, '4-2-1 split: topCount = 4');
+  assert(result.winnerCount === 4, '4-2-1 split: 4 winners');
+  assert(result.pot === 420, '4-2-1 split: pot = 420');
+  assert(result.payoutPerWinner === 105, '4-2-1 split: payout = 105 each');
 }
 
 // ---------------------------------------------------------------------------
-// 6b. Two-player game completes round successfully
+// 4. Single Valid Revealer
 // ---------------------------------------------------------------------------
-console.log('\n6b. Two-player game completes round');
-
-{
-  const salt = 'aaa2';
-  const players = [
-    { username: 'alice', score: 0.30, balance: 100, committed: true, revealed: true, hash: makeCommit(0.30, salt) },
-    { username: 'bob',   score: 0.70, balance: 100, committed: true, revealed: true, hash: makeCommit(0.70, salt) },
-  ];
-
-  const result = computeRoundResult(players, [], [], 3);
-  assert(!result.cancelled, 'Round not cancelled with 2 reveals');
-  assert(typeof result.mu === 'number', 'mu is a number');
-  assert(approx(result.mu, 0.50, 0.01), `mu ≈ 0.50 (got ${result.mu})`);
-}
-
-// ---------------------------------------------------------------------------
-// 7. Player with 0 balance has stake = 0 (spectator)
-// ---------------------------------------------------------------------------
-console.log('\n7. Zero-balance spectator');
-
-{
-  const salt = 'bbb';
-  const players = [
-    { username: 'alice',    score: 0.30, balance: 100, committed: true, revealed: true, hash: makeCommit(0.30, salt) },
-    { username: 'bob',      score: 0.50, balance: 100, committed: true, revealed: true, hash: makeCommit(0.50, salt) },
-    { username: 'carol',    score: 0.70, balance: 100, committed: true, revealed: true, hash: makeCommit(0.70, salt) },
-    { username: 'spectator', score: 0.99, balance: 0, committed: true, revealed: true, hash: makeCommit(0.99, salt) },
-  ];
-
-  const result = computeRoundResult(players, [], [], 4);
-  assert(!result.cancelled, 'Round not cancelled');
-  const spectator = result.players.find(p => p.username === 'spectator');
-  assert(spectator && spectator.stake === 0, 'Spectator has stake 0');
-  assert(spectator && spectator.slash === 0, 'Spectator not slashed (stake 0)');
-}
-
-// ---------------------------------------------------------------------------
-// 8. Weight cap (10% max weight)
-// ---------------------------------------------------------------------------
-console.log('\n8. Weight cap — rich player capped at 10%');
-
-{
-  const salt = 'ccc';
-  // All players have balance 100 → stake = min(100, 100) = 100
-  // sum stakes = 500; 10% cap = 50 → all weights capped at 50 each
-  const players = [
-    { username: 'rich',    score: 0.50, balance: 100, committed: true, revealed: true, hash: makeCommit(0.50, salt) },
-    { username: 'p1',      score: 0.40, balance: 100, committed: true, revealed: true, hash: makeCommit(0.40, salt) },
-    { username: 'p2',      score: 0.60, balance: 100, committed: true, revealed: true, hash: makeCommit(0.60, salt) },
-    { username: 'p3',      score: 0.52, balance: 100, committed: true, revealed: true, hash: makeCommit(0.52, salt) },
-    { username: 'outlier', score: 0.99, balance: 100, committed: true, revealed: true, hash: makeCommit(0.99, salt) },
-  ];
-
-  const result = computeRoundResult(players, [], [], 5);
-  assert(!result.cancelled, 'Round not cancelled');
-  // All with balance 100 → stake = 100; sumStakes = 500; cap = 50; all weights = 50
-  assert(typeof result.mu === 'number', 'mu computed');
-}
-
-// ---------------------------------------------------------------------------
-// 9. Leak detection
-// ---------------------------------------------------------------------------
-console.log('\n9. Leak detection');
-
-{
-  const salt = 'ddd';
-  const leakerScore = 0.75;
-  const msgId = 'msg-1';
-  const players = [
-    { username: 'leaker', score: leakerScore, balance: 100, committed: true, revealed: true, hash: makeCommit(leakerScore, salt) },
-    { username: 'reporter', score: 0.50, balance: 100, committed: true, revealed: true, hash: makeCommit(0.50, salt) },
-    { username: 'carol',    score: 0.52, balance: 100, committed: true, revealed: true, hash: makeCommit(0.52, salt) },
-    { username: 'dave',     score: 0.48, balance: 100, committed: true, revealed: true, hash: makeCommit(0.48, salt) },
-  ];
-  const chatMessages = [{ id: msgId, username: 'leaker', text: 'I am voting 0.75 obviously', timestamp: Date.now() }];
-  const leakReports = [{ messageId: msgId, reporterUsername: 'reporter', suspectUsername: 'leaker' }];
-
-  const result = computeRoundResult(players, leakReports, chatMessages, 6);
-  const leaker = result.players.find(p => p.username === 'leaker');
-  assert(leaker && leaker.isLeaker, 'Leaker identified');
-  assert(leaker && !leaker.coherent, 'Leaker treated as incoherent');
-  assert(leaker && approx(leaker.slash, 0.09 * 100, 0.01), `Leaker slashed 9% (got ${leaker?.slash})`);
-
-  const reporter = result.players.find(p => p.username === 'reporter');
-  assert(reporter && reporter.reward > 0, 'Reporter gets bounty');
-}
-
-// ---------------------------------------------------------------------------
-// 10. applyBalanceChanges
-// ---------------------------------------------------------------------------
-console.log('\n10. applyBalanceChanges');
+console.log('\n4. Single Valid Revealer');
 
 {
   const players = [
-    { username: 'alice', balance: 100 },
-    { username: 'bob', balance: 100 },
+    makePlayer('a1', 'Alice', 0, true),
+    makePlayer('a2', 'Bob', null, false),
+    makePlayer('a3', 'Carol', null, false),
   ];
-  const roundResult = {
-    players: [
-      { username: 'alice', slash: 3, reward: 0 },
-      { username: 'bob', slash: 0, reward: 3 },
-    ],
-  };
-  const changes = applyBalanceChanges(players, roundResult);
-  const alice = changes.find(c => c.username === 'alice');
-  const bob = changes.find(c => c.username === 'bob');
-  assert(alice && alice.newBalance === 97, `Alice balance: 97 (got ${alice?.newBalance})`);
-  assert(bob && bob.newBalance === 103, `Bob balance: 103 (got ${bob?.newBalance})`);
-  assert(alice && alice.delta === -3, `Alice delta: -3 (got ${alice?.delta})`);
+  const result = settleRound(players, question);
+
+  assert(!result.voided, 'Single revealer: round not voided');
+  assert(result.validRevealCount === 1, 'Single revealer: validRevealCount = 1');
+  assert(result.winnerCount === 1, 'Single revealer: 1 winner');
+  assert(result.pot === 180, 'Single revealer: pot = 180');
+  assert(result.payoutPerWinner === 180, 'Single revealer: winner takes whole pot');
+
+  const alice = result.players.find(p => p.accountId === 'a1');
+  assert(alice && alice.netDelta === 120, 'Single revealer: winner net = 180 - 60 = 120');
+  assert(alice && !alice.earnsCoordinationCredit, 'Single revealer: topCount=1 so no coordination credit');
 }
 
 // ---------------------------------------------------------------------------
-// 11. Non-committing player treated as incoherent
+// 5. Zero Valid Reveals = Void
 // ---------------------------------------------------------------------------
-console.log('\n11. Non-committing player is incoherent');
+console.log('\n5. Zero Valid Reveals = Void');
 
 {
-  const salt = 'eee';
   const players = [
-    { username: 'alice', score: 0.30, balance: 100, committed: true,  revealed: true,  hash: makeCommit(0.30, salt) },
-    { username: 'bob',   score: 0.50, balance: 100, committed: true,  revealed: true,  hash: makeCommit(0.50, salt) },
-    { username: 'carol', score: 0.70, balance: 100, committed: true,  revealed: true,  hash: makeCommit(0.70, salt) },
-    { username: 'dave',  score: null, balance: 100, committed: false, revealed: false, hash: null },
+    makePlayer('a1', 'Alice', null, false),
+    makePlayer('a2', 'Bob', null, false),
+    makePlayer('a3', 'Carol', null, false),
   ];
+  const result = settleRound(players, question);
 
-  // Need 2 valid reveals → ok (alice, bob, carol provide 3)
-  const result = computeRoundResult(players, [], [], 7);
-  assert(!result.cancelled, 'Round proceeds with 3 valid reveals');
-  const dave = result.players.find(p => p.username === 'dave');
-  assert(dave && !dave.coherent, 'Non-committing Dave is incoherent');
-  assert(dave && dave.slash > 0, `Dave slashed (got ${dave?.slash})`);
+  assert(result.voided === true, 'Zero reveals: voided = true');
+  assert(result.voidReason === 'zero_valid_reveals', 'Zero reveals: correct void reason');
+  assert(result.players.every(p => p.antePaid === 0), 'Zero reveals: no ante charged');
+  assert(result.players.every(p => p.netDelta === 0), 'Zero reveals: all net delta = 0');
+  assert(result.players.every(p => !p.earnsCoordinationCredit), 'Zero reveals: no coordination credit');
 }
 
 // ---------------------------------------------------------------------------
-// 12. computeLeavePenalty
+// 6. Tied Pluralities
 // ---------------------------------------------------------------------------
-console.log('\n12. computeLeavePenalty');
+console.log('\n6. Tied Pluralities');
 
 {
-  // Normal balance (100) → stake = 100, penalty = 3 × 3% × 100 = 9
-  assert(approx(computeLeavePenalty(100), 9), `Penalty for balance 100 = 9 (got ${computeLeavePenalty(100)})`);
+  // 5 players: 2-2-1 split (options 0 and 1 tied at 2 each)
+  const players = [
+    makePlayer('a1', 'Alice', 0),
+    makePlayer('a2', 'Bob', 0),
+    makePlayer('a3', 'Carol', 1),
+    makePlayer('a4', 'Dave', 1),
+    makePlayer('a5', 'Eve', 2),
+  ];
+  const result = settleRound(players, question);
 
-  // Low balance (50) → stake = 50, penalty = 3 × 3% × 50 = 4.5
-  assert(approx(computeLeavePenalty(50), 4.5), `Penalty for balance 50 = 4.5 (got ${computeLeavePenalty(50)})`);
+  assert(result.topCount === 2, '2-2-1 tie: topCount = 2');
+  assert(result.winningOptionIndexes.length === 2, '2-2-1 tie: 2 winning option indexes');
+  assert(result.winnerCount === 4, '2-2-1 tie: 4 winners (2 from each tied option)');
+  assert(result.pot === 300, '2-2-1 tie: pot = 300');
+  assert(result.payoutPerWinner === 75, '2-2-1 tie: payout = floor(300/4) = 75');
 
-  // Zero balance → stake = 0, penalty = 0
-  assert(computeLeavePenalty(0) === 0, `Penalty for balance 0 = 0 (got ${computeLeavePenalty(0)})`);
+  const winners = result.players.filter(p => p.wonRound);
+  assert(winners.length === 4, '2-2-1 tie: 4 players won');
+  assert(winners.every(p => p.earnsCoordinationCredit), '2-2-1 tie: winners earn coordination credit (topCount >= 2)');
 
-  // High balance (500) → stake capped at 100, penalty = 3 × 3% × 100 = 9
-  assert(approx(computeLeavePenalty(500), 9), `Penalty for balance 500 = 9 (got ${computeLeavePenalty(500)})`);
+  const eve = result.players.find(p => p.accountId === 'a5');
+  assert(eve && !eve.wonRound, '2-2-1 tie: minority picker lost');
+  assert(eve && !eve.earnsCoordinationCredit, '2-2-1 tie: loser no coordination credit');
+}
 
-  // Negative balance → stake = 0, penalty = 0
-  assert(computeLeavePenalty(-10) === 0, `Penalty for balance -10 = 0 (got ${computeLeavePenalty(-10)})`);
+// ---------------------------------------------------------------------------
+// 7. All Distinct (topCount=1)
+// ---------------------------------------------------------------------------
+console.log('\n7. All Distinct (topCount=1)');
+
+{
+  const players = [
+    makePlayer('a1', 'Alice', 0),
+    makePlayer('a2', 'Bob', 1),
+    makePlayer('a3', 'Carol', 2),
+  ];
+  const result = settleRound(players, question);
+
+  assert(result.topCount === 1, 'All distinct: topCount = 1');
+  assert(result.winnerCount === 3, 'All distinct: all 3 win (tied at 1 each)');
+  assert(result.winningOptionIndexes.length === 3, 'All distinct: 3 winning option indexes');
+  assert(result.players.every(p => p.wonRound), 'All distinct: everyone wins');
+  assert(result.players.every(p => !p.earnsCoordinationCredit), 'All distinct: topCount=1 so no coordination credit');
+}
+
+// ---------------------------------------------------------------------------
+// 8. Pot Math Verification
+// ---------------------------------------------------------------------------
+console.log('\n8. Pot Math Verification');
+
+{
+  // 3 players
+  const p3 = [makePlayer('a1', 'A', 0), makePlayer('a2', 'B', 0), makePlayer('a3', 'C', 0)];
+  const r3 = settleRound(p3, question);
+  assert(r3.pot === 3 * ROUND_ANTE, `3 players: pot = ${3 * ROUND_ANTE}`);
+  assert(r3.pot === 180, '3 players: pot = 180');
+}
+
+{
+  // 5 players
+  const p5 = [
+    makePlayer('a1', 'A', 0), makePlayer('a2', 'B', 0), makePlayer('a3', 'C', 0),
+    makePlayer('a4', 'D', 0), makePlayer('a5', 'E', 0),
+  ];
+  const r5 = settleRound(p5, question);
+  assert(r5.pot === 300, '5 players: pot = 300');
+}
+
+{
+  // 7 players
+  const p7 = [
+    makePlayer('a1', 'A', 0), makePlayer('a2', 'B', 0), makePlayer('a3', 'C', 0),
+    makePlayer('a4', 'D', 0), makePlayer('a5', 'E', 0), makePlayer('a6', 'F', 0),
+    makePlayer('a7', 'G', 0),
+  ];
+  const r7 = settleRound(p7, question);
+  assert(r7.pot === 420, '7 players: pot = 420');
+}
+
+{
+  // Integer division floor check: 7 players, 3 winners => floor(420/3) = 140
+  const players = [
+    makePlayer('a1', 'A', 0), makePlayer('a2', 'B', 0), makePlayer('a3', 'C', 0),
+    makePlayer('a4', 'D', 1), makePlayer('a5', 'E', 1),
+    makePlayer('a6', 'F', 2), makePlayer('a7', 'G', 3),
+  ];
+  const result = settleRound(players, question);
+  assert(result.payoutPerWinner === Math.floor(420 / 3), 'Integer division floor: floor(420/3) = 140');
+}
+
+// ---------------------------------------------------------------------------
+// 9. Forfeited Player Handling
+// ---------------------------------------------------------------------------
+console.log('\n9. Forfeited Player Handling');
+
+{
+  // Forfeited player: attached but validReveal = false
+  const players = [
+    makePlayer('a1', 'Alice', 0, true, false),
+    makePlayer('a2', 'Bob', 0, true, false),
+    { accountId: 'a3', displayName: 'Carol', optionIndex: null, validReveal: false, forfeited: true, attached: true },
+  ];
+  const result = settleRound(players, question);
+
+  assert(!result.voided, 'Forfeited player: round not voided');
+  assert(result.pot === 180, 'Forfeited player: pot includes forfeited player ante');
+  assert(result.validRevealCount === 2, 'Forfeited player: only 2 valid reveals');
+
+  const carol = result.players.find(p => p.accountId === 'a3');
+  assert(carol && !carol.wonRound, 'Forfeited player did not win');
+  assert(carol && carol.netDelta === -60, 'Forfeited player loses ante');
+}
+
+// ---------------------------------------------------------------------------
+// 10. Coordination Credit Rules
+// ---------------------------------------------------------------------------
+console.log('\n10. Coordination Credit Rules');
+
+// topCount >= 2: winners earn coordination credit
+{
+  const players = [
+    makePlayer('a1', 'Alice', 0),
+    makePlayer('a2', 'Bob', 0),
+    makePlayer('a3', 'Carol', 1),
+  ];
+  const result = settleRound(players, question);
+  const winners = result.players.filter(p => p.wonRound);
+  const losers = result.players.filter(p => !p.wonRound);
+
+  assert(result.topCount >= 2, 'topCount >= 2 case confirmed');
+  assert(winners.every(p => p.earnsCoordinationCredit), 'topCount >= 2: winners earn coordination credit');
+  assert(losers.every(p => !p.earnsCoordinationCredit), 'Losers never earn coordination credit');
+}
+
+// topCount = 1 with single revealer: no coordination credit
+{
+  const players = [
+    makePlayer('a1', 'Alice', 0, true),
+    makePlayer('a2', 'Bob', null, false),
+    makePlayer('a3', 'Carol', null, false),
+  ];
+  const result = settleRound(players, question);
+
+  assert(result.topCount === 1, 'Single revealer: topCount = 1');
+  const alice = result.players.find(p => p.accountId === 'a1');
+  assert(alice && !alice.earnsCoordinationCredit, 'Single revealer: no coordination credit');
+}
+
+// topCount = 1 with all distinct: no coordination credit
+{
+  const players = [
+    makePlayer('a1', 'Alice', 0),
+    makePlayer('a2', 'Bob', 1),
+    makePlayer('a3', 'Carol', 2),
+  ];
+  const result = settleRound(players, question);
+
+  assert(result.topCount === 1, 'All distinct: topCount = 1');
+  assert(result.players.every(p => !p.earnsCoordinationCredit), 'All distinct: no coordination credit for anyone');
+}
+
+// Voided round: no coordination credit
+{
+  const players = [
+    makePlayer('a1', 'Alice', null, false),
+    makePlayer('a2', 'Bob', null, false),
+  ];
+  const result = settleRound(players, question);
+
+  assert(result.voided, 'Voided round confirmed');
+  assert(result.players.every(p => !p.earnsCoordinationCredit), 'Voided round: no coordination credit for anyone');
 }
 
 // ---------------------------------------------------------------------------
 // Summary
 // ---------------------------------------------------------------------------
-console.log(`\n${'─'.repeat(40)}`);
-console.log(`Results: ${passed} passed, ${failed} failed`);
-
-if (failed > 0) {
-  process.exit(1);
-}
+console.log(`\nResults: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Summary

- Replaces the room-code prototype with the canonical public product defined in `docs/game-spec.md`
- Wallet-backed auth (ethers.js signature verification), FIFO public queue with 20s fill timer, 3/5/7 odd-size auto-start
- Exact-match plurality settlement with fixed 60-token ante, coordination credit gated by topCount >= 2
- Persistent signed-integer token balances across matches, abuse-filtered leaderboard
- Select-only focal-point questions (45 canonical prompts, no sliders or estimation)
- 15s reconnect grace, forfeit handling, auto-requeue toggle
- Frontend: wallet sign-in, queue waiting room, select-only play, results with wonRound vs coordinationCredit shown separately
- 94 passing tests covering commit-reveal, plurality settlement, voids, ties, forfeits, and coordination credit rules

## What changed

| File | Change |
|---|---|
| `src/domain/commitReveal.js` | New: SHA-256 commit/verify with `optionIndex:salt` |
| `src/domain/settlement.js` | New: plurality settlement engine |
| `src/domain/questions.js` | New: 45 select-only canonical questions |
| `src/db.js` | Rewrite: 6-table schema (accounts, player_stats, auth_challenges, matches, match_players, vote_logs) |
| `src/auth.js` | New: wallet challenge/verify + session management |
| `src/matchmaking.js` | New: FIFO queue, forming match timer, even-size pushback |
| `src/gameManager.js` | Rewrite: queue-based orchestration replacing room-code lobbies |
| `server.js` | Rewrite: REST API (auth, profile, leaderboard, export, admin) + authenticated WebSocket |
| `public/index.html` | Rewrite: wallet sign-in, queue UI, select-only play, canonical results |
| `test/test.js` | Rewrite: 94 tests for canonical plurality engine |

## Removed from active path

Room codes, host role, sliders, mean/sigma scoring, leak reporting, per-game balance resets, username-based auth.