### PR TITLE
Add browser wallet for guest play

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -563,7 +563,9 @@ async function checkSession() {
           S.isGuestWallet = true;
         }
       }
-    } catch (_) {}
+    } catch (_) {
+      try { localStorage.removeItem('schelling_guest_pk'); } catch (_e) {}
+    }
     if (S.displayName) {
       onAuthComplete();
     }


### PR DESCRIPTION
## Summary

- Adds a "Play as Guest" button below the existing "Connect Ethereum Wallet" button on the auth screen
- Generates a random Ethereum keypair in-browser via `ethers.Wallet.createRandom()` and stores the private key in `localStorage`
- Uses the same challenge/sign/verify auth flow as MetaMask, just without any wallet popup
- Shows "(guest)" indicator next to the display name in the header
- Guest identity persists across logouts and page refreshes via the stored key

## Why

Users without a wallet extension are currently blocked from playing. Since the wallet is only used for authentication (no on-chain transactions), a browser-generated keypair works identically. This removes the biggest friction point for casual users who just want to try the game.

## Details

Frontend-only change (`public/app.html`). Zero backend modifications needed because `ethers.verifyMessage()` is wallet-agnostic: it doesn't care whether the signature came from MetaMask or an in-memory wallet.

The `localStorage` key (`schelling_guest_pk`) survives logout so returning guests keep the same identity. Clearing site data resets it, which is communicated in a small note below the button.