### PR TITLE
Add seed phrase export/import for guest wallets

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -405,7 +405,19 @@ const $ = (sel) => document.querySelector(sel);
 const $$ = (sel) => document.querySelectorAll(sel);
 
 // ── Guest wallet ─────────────────────────────────────────────────
-const GUEST_KEY = 'schelling_guest_pk';
+const GUEST_KEY = 'schelling_guest_secret';
+// Migrate from legacy key name on startup (v1 stored only private keys)
+(function migrateGuestKey() {
+  try {
+    if (!localStorage.getItem(GUEST_KEY)) {
+      const legacy = localStorage.getItem('schelling_guest_pk');
+      if (legacy) {
+        localStorage.setItem(GUEST_KEY, legacy);
+        localStorage.removeItem('schelling_guest_pk');
+      }
+    }
+  } catch (_) {}
+})();
 
 // Construct a wallet from a stored secret (mnemonic or private key)
 function walletFromSecret(secret) {


### PR DESCRIPTION
## Summary

- Store mnemonic phrase instead of raw private key for new guest wallets (backwards compatible with existing keys via auto-detection)
- Add "Backup" button in the header for guest users that opens an overlay showing their 12-word seed phrase with a Copy button
- Add "Import Existing Wallet" on the auth screen that accepts a seed phrase or private key to restore identity on a new device/browser

## Why

PR #65 introduced browser-generated guest wallets, but the identity was trapped in localStorage with no way to back it up or move it. Users who clear site data or switch devices would permanently lose their account. Now they can export their seed phrase and re-import it anywhere.