### PR TITLE
Fix landing page overclaiming

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -568,7 +568,7 @@ footer{
       <div class="concept-card reveal reveal-delay-4">
         <div class="num">04</div>
         <h3>10 Rounds</h3>
-        <p>Each match is 10 rounds of different questions. Repeating over many rounds rewards consistent coordination more than any single lucky guess.</p>
+        <p>Each match is 10 rounds of different questions. Over many rounds, consistent coordination is rewarded more than any single lucky guess.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary

- Hero subtitle: "No collusion" → "No safe collusion" to align with the nuanced "No Safe Collusion" card below it; players can attempt collusion out-of-band, they just cannot prove their commitments
- Card 01: "The only winning strategy is reading the focal point" → "The mechanism is designed to make focal-point reasoning the most reliable approach"; frames focal-point reasoning as design intent rather than a proven conclusion
- Card 04: "One lucky guess will not carry you through" → "Repeating over many rounds rewards consistent coordination more than any single lucky guess"; comparative claim derivable from the payout math, not an absolute exclusion of luck

Closes #61