### PR TITLE
fix: prevent WebSocket reconnect loop on logout

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -691,7 +691,7 @@ function onAuthComplete() {
 $('#logout-btn').addEventListener('click', async () => {
   intentionalClose = true;
   wsRetryCount = 0;
-  if (wsRetryTimer) { clearTimeout(wsRetryTimer); wsRetryTimer = null; }
+  if (wsRetryTimer !== null) { clearTimeout(wsRetryTimer); wsRetryTimer = null; }
   if (S.ws) { S.ws.close(); S.ws = null; }
   try { await api('POST', '/api/logout'); } catch (_) {}
   S.walletAddress = null;


### PR DESCRIPTION
## Summary

Fixes #80: logout triggers the WebSocket reconnect loop.

**Root cause**: clicking logout closed the socket but did not prevent the reconnect backoff from firing. Three specific gaps existed:

1. A reconnect timer (`setTimeout`) scheduled before logout would still fire afterward, since the timer ID was never tracked or cancelled.
2. `intentionalClose` was reset to `false` at the top of `connectWebSocket()`, so a stale socket's `onclose` firing after a quick re-login would see the flag cleared and schedule reconnects.
3. The logout handler set `intentionalClose` only inside `if (S.ws)` and only after the async `/api/logout` call, leaving a window for races.

## Changes

### Commit 1: `7639dea` — initial fix
- Added `intentionalClose` flag to suppress reconnection after logout.

### Commit 2: `8deb2b0` — address review feedback (round 1)
- **Timer tracking**: added `wsRetryTimer` variable; store the `setTimeout` return value when scheduling reconnect; `clearTimeout(wsRetryTimer)` in the logout handler.
- **Socket-scoped onclose**: capture `const thisWs = S.ws` in `connectWebSocket()` and guard `onclose` with `if (intentionalClose || thisWs !== S.ws) return;` so stale socket closes are ignored.
- **Flag lifecycle**: moved `intentionalClose = false` from `connectWebSocket()` to `onAuthComplete()`, so it only resets when a new authenticated session begins.
- **Logout ordering**: set `intentionalClose = true` and cancel the timer synchronously at the top of the logout handler, before the async `/api/logout` call.

### Commit 3: `fa64881` — address review feedback (round 2)
- **Clear stale `wsRetryTimer`**: set `wsRetryTimer = null` at the start of `connectWebSocket()` (timer has fired, clear the reference) and in `onopen` (connection succeeded, no pending retry), so the reference accurately reflects whether a retry is pending.
- **Reset `wsRetryCount` on logout**: reset `wsRetryCount = 0` in the logout handler alongside the other cleanup, preventing a subsequent session from inheriting a stale count and hitting `WS_MAX_RETRIES` prematurely.