### PR TITLE
fix: read error field from backend JSON responses

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -502,7 +502,7 @@ async function api(method, path, body) {
   const res = await fetch(path, opts);
   if (!res.ok) {
     const err = await res.json().catch(() => ({ message: res.statusText }));
-    throw new Error(err.message || res.statusText);
+    throw new Error(err.error || err.message || res.statusText);
   }
   return res.json();
 }


### PR DESCRIPTION
## Summary
- The `api()` helper in `public/app.html` read `err.message` but the backend's `errorResponse()` returns errors as `{ error: '...' }`. Users saw generic HTTP status text (e.g. "Bad Request") instead of the actual error message (e.g. "displayName must be 1-20 characters: A-Za-z0-9_-").
- Added `err.error` as the first fallback in the error chain: `err.error || err.message || res.statusText`.

Closes #74