### PR TITLE
[codex] Fix workerd websocket promise handling

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -480,7 +480,10 @@ export class GameRoom {
     const matchId = crypto.randomUUID();
     this.formingMatch = null;
 
-    this._startMatch(players, matchId);
+    this._waitUntil(
+      this._startMatch(players, matchId),
+      `start match ${matchId}`,
+    );
     this._broadcastQueueState();
   }
 

--- a/test/worker/game-room-async.test.ts
+++ b/test/worker/game-room-async.test.ts
@@ -134,6 +134,32 @@ describe('GameRoom async task tracking', () => {
     expect(player.salt).toBe(salt);
   });
 
+  it('tracks match start from _startFormingMatch with state.waitUntil', async () => {
+    const { room, waitUntil } = createRoom();
+    const startMatch = vi
+      .spyOn(room, '_startMatch')
+      .mockResolvedValue(undefined);
+    vi.spyOn(room, '_broadcastQueueState').mockImplementation(() => {});
+
+    // Set up a forming match with 3 players (minimum odd count)
+    room.formingMatch = {
+      players: ['acct-1', 'acct-2', 'acct-3'],
+      timer: null,
+      fillDeadlineMs: null,
+    };
+
+    room._startFormingMatch();
+
+    expect(startMatch).toHaveBeenCalledTimes(1);
+    expect(startMatch.mock.calls[0]![0]).toEqual([
+      'acct-1',
+      'acct-2',
+      'acct-3',
+    ]);
+    expect(waitUntil).toHaveBeenCalledTimes(1);
+    await waitUntil.mock.calls[0]![0];
+  });
+
   it('tracks match end after results with state.waitUntil', async () => {
     const { room, waitUntil } = createRoom();
     const endMatch = vi.spyOn(room, '_endMatch').mockResolvedValue(undefined);


### PR DESCRIPTION
## Summary

Fixes ignored-promise warnings in workerd by ensuring async work kicked off from WebSocket events and timer/sync transitions is tracked via Durable Object `state.waitUntil()`, keeping important D1 writes attached to the DO lifetime.

- Refactored WebSocket `message` handler to be synchronous; schedules async processing via a new `_waitUntil()` helper
- Wrapped round finalization and match-end transitions so they no longer drop promises when triggered from timers or sync code paths
- Routed `_startMatch()` (called fire-and-forget from `_startFormingMatch`) through `_waitUntil()` so its D1 writes are also attached to the DO lifetime
- Added worker-focused unit tests asserting these paths schedule background work through `state.waitUntil()`

Closes #96