### PR TITLE
fix: only clear auth state after successful logout API call

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -688,7 +688,14 @@ $('#logout-btn').addEventListener('click', async () => {
   wsRetryCount = 0;
   if (wsRetryTimer !== null) { clearTimeout(wsRetryTimer); wsRetryTimer = null; }
   if (S.ws) { S.ws.close(); S.ws = null; }
-  try { await api('POST', '/api/logout'); } catch (_) {}
+  try {
+    await api('POST', '/api/logout');
+  } catch (_) {
+    notify('Logout failed. Please try again.', 'error');
+    intentionalClose = false;
+    connectWebSocket();
+    return;
+  }
   S.walletAddress = null;
   S.accountId = null;
   S.displayName = null;


### PR DESCRIPTION
## Summary
- Fix the logout handler in `public/app.html` so local auth state is only cleared when `POST /api/logout` succeeds
- On failure: surface an error notification, reset `intentionalClose`, re-open the WebSocket, and return early
- Previously, the catch block swallowed errors and unconditionally cleared state, leaving the cookie intact while the UI showed the user as logged out

Closes #106