### PR TITLE
fix: show logout button on display-name claim screen

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -470,24 +470,43 @@ function notify(msg, type = '') {
   setTimeout(() => el.remove(), 4000);
 }
 
-// ── View switching ──────────────────────────────────────────────
-function showView(name) {
-  S.view = name;
-  $$('.view').forEach(v => v.classList.remove('active'));
-  $(`#${name}-view`).classList.add('active');
-
-  // header profile: show whenever authenticated (accountId set), even before display name is claimed
+// ── Header profile ──────────────────────────────────────────────
+function updateHeaderProfile() {
   if (S.accountId) {
     $('#header-profile').classList.remove('hidden');
     $('#header-name').textContent = S.displayName || S.accountId.slice(0, 6) + '…';
     $('#header-balance').textContent = S.tokenBalance + ' tokens';
     $('#backup-seed-btn').classList.toggle('hidden', !S.isBrowserWallet);
   }
+}
+
+// ── View switching ──────────────────────────────────────────────
+function showView(name) {
+  S.view = name;
+  $$('.view').forEach(v => v.classList.remove('active'));
+  $(`#${name}-view`).classList.add('active');
+
+  updateHeaderProfile();
 
   // nav visibility
   $('#nav-queue').classList.toggle('hidden', name === 'auth');
   // hide logout during active matches
   $('#logout-btn').classList.toggle('hidden', name === 'play');
+}
+
+// ── Name-claim UI (shared by authenticateWithWallet + checkSession) ──
+function showNameClaim(statusText) {
+  updateHeaderProfile();
+  $('#auth-status').textContent = statusText;
+  $('#name-section').classList.remove('hidden');
+  $('#connect-wallet-btn').classList.add('hidden');
+  $('#browser-wallet-btn').classList.add('hidden');
+  $('.auth-divider').classList.add('hidden');
+  $$('.browser-wallet-note').forEach(el => el.classList.add('hidden'));
+  $('#show-import-btn').classList.add('hidden');
+  $('#import-section').classList.add('hidden');
+  $('#show-import-btn').setAttribute('aria-expanded', 'false');
+  $('#import-input').value = '';
 }
 
 // ── REST helpers ────────────────────────────────────────────────
@@ -527,16 +546,7 @@ async function authenticateWithWallet(address, signFn, { signingMsg, successMsg,
   S.isBrowserWallet = isBrowserWallet;
 
   if (result.requiresDisplayName) {
-    status.textContent = successMsg + ' Please claim a display name.';
-    $('#name-section').classList.remove('hidden');
-    $('#connect-wallet-btn').classList.add('hidden');
-    $('#browser-wallet-btn').classList.add('hidden');
-    $('.auth-divider').classList.add('hidden');
-    $$('.browser-wallet-note').forEach(el => el.classList.add('hidden'));
-    $('#show-import-btn').classList.add('hidden');
-    $('#import-section').classList.add('hidden');
-    $('#show-import-btn').setAttribute('aria-expanded', 'false');
-    $('#import-input').value = '';
+    showNameClaim(successMsg + ' Please claim a display name.');
   } else {
     S.displayName = result.displayName;
     onAuthComplete();
@@ -743,16 +753,7 @@ async function checkSession() {
     if (S.displayName) {
       onAuthComplete();
     } else {
-      $('#auth-status').textContent = 'Welcome back! Please claim a display name.';
-      $('#name-section').classList.remove('hidden');
-      $('#connect-wallet-btn').classList.add('hidden');
-      $('#browser-wallet-btn').classList.add('hidden');
-      $('.auth-divider').classList.add('hidden');
-      $$('.browser-wallet-note').forEach(el => el.classList.add('hidden'));
-      $('#show-import-btn').classList.add('hidden');
-      $('#import-section').classList.add('hidden');
-      $('#show-import-btn').setAttribute('aria-expanded', 'false');
-      $('#import-input').value = '';
+      showNameClaim('Welcome back! Please claim a display name.');
     }
   } catch (_) {
     // not logged in; check if wallet is available


### PR DESCRIPTION
## Summary

Fixes #102. The header profile (containing the logout button) was gated on `S.displayName` being truthy. When `requiresDisplayName` is true the user has no display name yet, so the header stayed hidden and there was no way to log out or switch wallets from the name-claim form.

**Commit 1** (`fix: show logout button on display-name claim screen`): Changes the header-profile visibility gate from `S.displayName` to `S.accountId`, so the logout button appears as soon as the user is authenticated.

**Commit 2** (`fix: show header profile during name-claim flow`):
- Extracts `updateHeaderProfile()` from `showView()` so header state can be updated independently of view transitions
- Introduces `showNameClaim()` helper to DRY the repeated name-claim DOM manipulations used in both `authenticateWithWallet()` and `checkSession()`
- Calls `updateHeaderProfile()` inside `showNameClaim()` so the logout button is visible during the name-claim flow