### PR TITLE
ci: add Codex PR review workflow

### DIFF
--- a/.github/codex/prompts/review.md
+++ b/.github/codex/prompts/review.md
@@ -1,0 +1,22 @@
+Review this pull request against its base branch.
+
+Focus on:
+- bugs and behavioral regressions
+- auth, session, or security issues
+- Worker, Durable Object, and reconnect/persistence edge cases
+- protocol mismatches between the worker, frontend, and tests
+- missing or insufficient test coverage when behavior changes
+
+Ignore style-only feedback unless it hides a bug.
+Do not praise the PR.
+Only report actionable findings.
+
+If there are no actionable findings, say exactly:
+No actionable findings.
+
+When you report a finding:
+1. Start with `[P1]`, `[P2]`, or `[P3]`.
+2. Include the file path and line number when you can determine them.
+3. Use one short paragraph that explains the problem, the user-visible impact, and any testing gap that matters.
+
+Keep the response concise and high signal.

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -1,0 +1,103 @@
+name: Codex PR Review
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: codex-pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  codex:
+    # Keep the OpenAI key off fork PR runs; same-repo PRs still get reviewed automatically.
+    if: >-
+      ${{
+        !github.event.pull_request.draft &&
+        github.event.pull_request.head.repo.full_name == github.repository
+      }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      final_message: ${{ steps.run_codex.outputs.final-message }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+
+      - name: Pre-fetch base and head refs
+        run: |
+          git fetch --no-tags origin \
+            ${{ github.event.pull_request.base.ref }} \
+            +refs/pull/${{ github.event.pull_request.number }}/head
+
+      - name: Run Codex
+        id: run_codex
+        uses: openai/codex-action@v1
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          prompt-file: .github/codex/prompts/review.md
+          output-file: codex-review.md
+          safety-strategy: drop-sudo
+          sandbox: read-only
+
+  post-feedback:
+    if: >-
+      ${{
+        needs.codex.result == 'success' &&
+        needs.codex.outputs.final_message != ''
+      }}
+    needs: codex
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Upsert Codex feedback comment
+        uses: actions/github-script@v7
+        env:
+          CODEX_FINAL_MESSAGE: ${{ needs.codex.outputs.final_message }}
+          CODEX_MARKER: '<!-- codex-pr-review -->'
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const marker = process.env.CODEX_MARKER;
+            const reviewBody = process.env.CODEX_FINAL_MESSAGE.trim();
+            const shortSha = context.payload.pull_request.head.sha.slice(0, 7);
+            const body = [
+              marker,
+              '## Codex Review',
+              '',
+              `Reviewed commit: \`${shortSha}\``,
+              '',
+              reviewBody,
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+
+            const existing = comments.find((comment) =>
+              comment.body?.includes(marker),
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body,
+            });


### PR DESCRIPTION
## Summary
- add a dedicated `Codex PR Review` workflow for pull requests into `main`
- run `openai/codex-action@v1` in a read-only sandbox and post the final result back to the PR
- store the review prompt in `.github/codex/prompts/review.md` and upsert a single bot comment per PR

## Notes
- this workflow only runs for same-repo PRs to avoid exposing the OpenAI key to fork-triggered runs
- repository setup still needs an `OPENAI_API_KEY` Actions secret for the workflow to execute

## Validation
- parsed `.github/workflows/codex-pr-review.yml` with Ruby `YAML.load_file`
- ran `git diff --check`
