### PR TITLE
fix: restore auth on databases missing auth_challenges.issued_at

### DIFF
--- a/src/worker/httpHandler.ts
+++ b/src/worker/httpHandler.ts
@@ -17,6 +17,15 @@ import {
 
 const DISPLAY_NAME_REGEX = /^[A-Za-z0-9_-]{1,20}$/;
 
+interface AuthChallengeRow {
+  challenge_id: string;
+  wallet_address: string;
+  nonce: string;
+  message: string;
+  expires_at: string;
+  issued_at?: number | null;
+}
+
 function jsonResponse(
   data: unknown,
   status = 200,
@@ -49,6 +58,51 @@ function escapeCsvField(value: unknown): string {
     return `"${s.replace(/"/g, '""')}"`;
   }
   return s;
+}
+
+function isMissingIssuedAtColumnError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    message.includes('no such column: issued_at') ||
+    message.includes('no column named issued_at')
+  );
+}
+
+async function insertAuthChallenge(
+  db: D1Database,
+  challengeId: string,
+  walletAddress: string,
+  nonce: string,
+  message: string,
+  expiresAt: string,
+  issuedAt: number,
+): Promise<void> {
+  try {
+    await db
+      .prepare(
+        'INSERT INTO auth_challenges (challenge_id, wallet_address, nonce, message, expires_at, issued_at) VALUES (?, ?, ?, ?, ?, ?)',
+      )
+      .bind(challengeId, walletAddress, nonce, message, expiresAt, issuedAt)
+      .run();
+  } catch (error) {
+    if (!isMissingIssuedAtColumnError(error)) throw error;
+
+    await db
+      .prepare(
+        'INSERT INTO auth_challenges (challenge_id, wallet_address, nonce, message, expires_at) VALUES (?, ?, ?, ?, ?)',
+      )
+      .bind(challengeId, walletAddress, nonce, message, expiresAt)
+      .run();
+  }
+}
+
+function parseIssuedAtFromChallengeMessage(message: string): number | null {
+  const match = /\nIssued: (\d+)$/.exec(message);
+  if (!match) return null;
+
+  const issuedAt = Number(match[1]);
+  if (!Number.isSafeInteger(issuedAt)) return null;
+  return issuedAt;
 }
 
 export async function handleHttpRequest(
@@ -105,11 +159,15 @@ export async function handleHttpRequest(
     const expiresAt = new Date(issuedAt + 5 * 60 * 1000).toISOString();
     const message = buildChallengeMessage(normalized, nonce, issuedAt);
 
-    await env.DB.prepare(
-      'INSERT INTO auth_challenges (challenge_id, wallet_address, nonce, message, expires_at, issued_at) VALUES (?, ?, ?, ?, ?, ?)',
-    )
-      .bind(challengeId, normalized, nonce, message, expiresAt, issuedAt)
-      .run();
+    await insertAuthChallenge(
+      env.DB,
+      challengeId,
+      normalized,
+      nonce,
+      message,
+      expiresAt,
+      issuedAt,
+    );
 
     return jsonResponse({ challengeId, message, expiresAt });
   }
@@ -138,17 +196,13 @@ export async function handleHttpRequest(
       'SELECT * FROM auth_challenges WHERE challenge_id = ? AND wallet_address = ?',
     )
       .bind(challengeId, normalized)
-      .first()) as {
-      challenge_id: string;
-      wallet_address: string;
-      nonce: string;
-      message: string;
-      expires_at: string;
-      issued_at: number | null;
-    } | null;
+      .first()) as AuthChallengeRow | null;
 
     if (!challenge) return errorResponse('Invalid or expired challenge', 401);
-    if (challenge.issued_at == null) {
+    const challengeIssuedAt =
+      challenge.issued_at ??
+      parseIssuedAtFromChallengeMessage(challenge.message);
+    if (challengeIssuedAt == null) {
       // Pre-migration challenge row; force client to restart auth
       await env.DB.prepare('DELETE FROM auth_challenges WHERE challenge_id = ?')
         .bind(challengeId)
@@ -204,7 +258,7 @@ export async function handleHttpRequest(
     const token = createSessionCookie(
       normalized,
       challenge.nonce,
-      challenge.issued_at,
+      challengeIssuedAt,
       signature,
     );
     const requiresDisplayName = !account!.display_name;

--- a/test/worker/http-routes.test.ts
+++ b/test/worker/http-routes.test.ts
@@ -1,5 +1,8 @@
 import { env, exports } from 'cloudflare:workers';
 import { describe, expect, it } from 'vitest';
+import type { Env } from '../../src/types/worker-env';
+import { handleHttpRequest } from '../../src/worker/httpHandler';
+import { buildChallengeMessage } from '../../src/worker/session';
 import { createTestSession, createTestWallet, seedAccount } from './helpers';
 
 const HTTPS_BASE = 'https://test.local';
@@ -62,6 +65,52 @@ describe('HTTP routes', () => {
     expect(data).toEqual([]);
   });
 
+  it('POST /api/auth/challenge falls back when auth_challenges lacks issued_at', async () => {
+    const queries: string[] = [];
+    const fallbackDb = {
+      prepare(sql: string) {
+        queries.push(sql);
+        return {
+          bind: (..._params: unknown[]) => ({
+            run: async () => {
+              if (sql.includes('issued_at')) {
+                throw new Error(
+                  'table auth_challenges has no column named issued_at',
+                );
+              }
+              return {};
+            },
+          }),
+        };
+      },
+    } as unknown as D1Database;
+
+    const resp = await handleHttpRequest(
+      new Request(`${HTTPS_BASE}/api/auth/challenge`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          walletAddress: '0x1234567890123456789012345678901234567890',
+        }),
+      }),
+      {
+        DB: fallbackDb,
+        GAME_ROOM: {} as DurableObjectNamespace,
+      } as Env,
+    );
+
+    expect(resp.status).toBe(200);
+    const data = (await resp.json()) as { message: string };
+    expect(data.message).toContain('Issued:');
+    expect(queries.some((q) => q.includes('issued_at'))).toBe(true);
+    expect(
+      queries.some(
+        (q) =>
+          q.includes('INSERT INTO auth_challenges') && !q.includes('issued_at'),
+      ),
+    ).toBe(true);
+  });
+
   it('POST /api/auth/challenge returns challengeId and message', async () => {
     const wallet = createTestWallet();
     const resp = await post('/api/auth/challenge', {
@@ -108,6 +157,46 @@ describe('HTTP routes', () => {
       requiresDisplayName: boolean;
     };
     expect(body.accountId).toBe(normalized);
+    expect(body.requiresDisplayName).toBe(true);
+  });
+
+  it('POST /api/auth/verify accepts legacy challenges with NULL issued_at', async () => {
+    const wallet = createTestWallet(7);
+    const challengeId = 'ch_legacy_issued_at';
+    const nonce = crypto.randomUUID();
+    const issuedAt = Date.now();
+    const message = buildChallengeMessage(
+      wallet.address.toLowerCase(),
+      nonce,
+      issuedAt,
+    );
+    const expiresAt = new Date(issuedAt + 5 * 60 * 1000).toISOString();
+
+    await env.DB.prepare(
+      'INSERT INTO auth_challenges (challenge_id, wallet_address, nonce, message, expires_at) VALUES (?, ?, ?, ?, ?)',
+    )
+      .bind(
+        challengeId,
+        wallet.address.toLowerCase(),
+        nonce,
+        message,
+        expiresAt,
+      )
+      .run();
+
+    const signature = await wallet.signMessage(message);
+    const verifyResp = await post('/api/auth/verify', {
+      challengeId,
+      walletAddress: wallet.address,
+      signature,
+    });
+
+    expect(verifyResp.status).toBe(200);
+    const body = (await verifyResp.json()) as {
+      accountId: string;
+      requiresDisplayName: boolean;
+    };
+    expect(body.accountId).toBe(wallet.address.toLowerCase());
     expect(body.requiresDisplayName).toBe(true);
   });
 


### PR DESCRIPTION
## Summary
- fall back when inserting auth challenges on D1 databases that do not have the `issued_at` column yet
- recover `issuedAt` from the signed challenge message during verify when legacy rows have `NULL` or no `issued_at`
- add worker-route coverage for both the fallback insert path and legacy verify path

## Why
Production auth is currently failing on `POST /api/auth/challenge` with a 500 because the Worker expects the `auth_challenges.issued_at` column, while the deployed D1 schema appears to still be on the pre-migration shape. This patch restores sign-in without requiring the migration to land first.

## Verification
- `npm run lint`
- `npm run typecheck`
- `npm run typecheck:worker`
- `npm test`
- `npx vitest run --config vitest.config.worker.ts test/worker/http-routes.test.ts`