### PR TITLE
fix: drain leftover queue after full-cap match starts

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -476,8 +476,8 @@ export class GameRoom {
     if (players.length < MIN_MATCH_SIZE) {
       this.waitingQueue.unshift(...players);
       this.formingMatch = null;
-      this._broadcastQueueState();
       this._tryFormMatch();
+      this._broadcastQueueState();
       return;
     }
 
@@ -488,8 +488,8 @@ export class GameRoom {
       this._startMatch(players, matchId),
       `start match ${matchId}`,
     );
-    this._broadcastQueueState();
     this._tryFormMatch();
+    this._broadcastQueueState();
   }
 
   // -------------------------------------------------------------------------

--- a/test/worker/game-room-async.test.ts
+++ b/test/worker/game-room-async.test.ts
@@ -208,6 +208,46 @@ describe('GameRoom async task tracking', () => {
     ]);
   });
 
+  it('immediately starts forming a leftover queue after a full-cap match', () => {
+    const { room } = createRoom();
+    vi.spyOn(room, '_startMatch').mockResolvedValue(undefined);
+    vi.spyOn(room, '_broadcastQueueState').mockImplementation(() => {});
+
+    room.waitingQueue = Array.from({ length: 24 }, (_, i) => `acct-${i + 1}`);
+    room._tryFormMatch();
+
+    // 21 reserved for the first match; the chained _tryFormMatch() picks up
+    // the remaining 3 into a new formingMatch before the broadcast fires.
+    expect(room.waitingQueue).toHaveLength(0);
+    expect(room.formingMatch?.players).toEqual([
+      'acct-22',
+      'acct-23',
+      'acct-24',
+    ]);
+
+    if (room.formingMatch?.timer) clearTimeout(room.formingMatch.timer);
+  });
+
+  it('broadcast reflects new formingMatch after full-cap drain', () => {
+    const { room } = createRoom();
+    vi.spyOn(room, '_startMatch').mockResolvedValue(undefined);
+
+    let capturedFormingMatch: typeof room.formingMatch = null;
+    vi.spyOn(room, '_broadcastQueueState').mockImplementation(() => {
+      capturedFormingMatch = room.formingMatch;
+    });
+
+    room.waitingQueue = Array.from({ length: 24 }, (_, i) => `acct-${i + 1}`);
+    room._tryFormMatch();
+
+    // The final broadcast must see the leftover formingMatch so clients
+    // receive the fill timer countdown.
+    expect(capturedFormingMatch).not.toBeNull();
+    expect(capturedFormingMatch?.players).toHaveLength(3);
+
+    if (room.formingMatch?.timer) clearTimeout(room.formingMatch.timer);
+  });
+
   it('tracks match end after results with state.waitUntil', async () => {
     const { room, waitUntil } = createRoom();
     const endMatch = vi.spyOn(room, '_endMatch').mockResolvedValue(undefined);


### PR DESCRIPTION
## Summary

- Bumps `MAX_MATCH_SIZE` from 7 to 21 (intended by 953eb88 / PR #121 but not applied to the constant)
- Adds `this._tryFormMatch()` in `_startFormingMatch()` to immediately drain leftover queue members into a new forming cycle instead of waiting for an unrelated event
- Moves `_tryFormMatch()` before `_broadcastQueueState()` so the broadcast reflects the new `formingMatch` state and clients see the fill timer countdown
- Adds two tests for the leftover-queue scenario: one verifying queue drain, one verifying the broadcast captures the new forming state

Closes #140