### PR TITLE
feat: add in-game rules/help modal

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -367,7 +367,7 @@ nav{display:flex;gap:.5rem}
 
     <div>
       <p class="rules-section-label">Round Flow</p>
-      <p class="rules-text">Each round has three phases: Commit (30s), Reveal (15s), Results (12s). Every attached player antes 60 per round.</p>
+      <p class="rules-text">Each round has three phases: Commit (60s), Reveal (15s), Results (20s). Every attached player antes 60 per round.</p>
     </div>
 
     <div>


### PR DESCRIPTION
## Summary

- Adds a **Rules** button to the nav bar in `app.html`, visible on all authenticated views
- Adds a modal overlay explaining settlement edge cases, coordination credit, voided rounds, solo revealer, and disconnect/forfeit behavior
- Includes two worked examples (2-1 split and solo reveal)
- Follows the existing `#seed-overlay` pattern: backdrop click, Escape key, and focus trap
- Phase timings match `src/domain/constants.ts` (Commit 60s, Reveal 15s, Results 20s)

Closes #138