### PR TITLE
[codex] Align branding with The Schelling Game

### DIFF
--- a/docs/game-design.md
+++ b/docs/game-design.md
@@ -1,14 +1,14 @@
-# Schelling Game Design
+# The Schelling Game Design
 
 Status: canonical game-rules document
 
-This document defines Schelling Game's rules and match logic. It is authoritative for gameplay behavior.
+This document defines the rules and match logic for The Schelling Game. It is authoritative for gameplay behavior.
 
 Authentication, transport, persistence, leaderboard implementation, and UI are out of scope.
 
 ## 1. Game Summary
 
-Schelling Game is a multiplayer coordination game. In each round, every player independently picks the option they expect the most other players to pick. Answers are hidden during commit, opened during reveal, and settled by exact-match plurality.
+The Schelling Game is a multiplayer coordination game. In each round, every player independently picks the option they expect the most other players to pick. Answers are hidden during commit, opened during reveal, and settled by exact-match plurality.
 
 The game distinguishes between two outcomes:
 

--- a/public/app.html
+++ b/public/app.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-<title>Schelling Game</title>
+<title>The Schelling Game</title>
 <script src="https://cdn.jsdelivr.net/npm/ethers@6/dist/ethers.umd.min.js"></script>
 <link rel="preconnect" href="https://fonts.googleapis.com"/>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
@@ -350,7 +350,7 @@ nav{display:flex;gap:.5rem}
 
 <script>
 /* ═══════════════════════════════════════════════════════════════════
-   Schelling Game Client
+   The Schelling Game client
    Vanilla JS, single-file. Connects via REST + WebSocket.
    ═══════════════════════════════════════════════════════════════════ */
 (function () {

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8"/>
 <meta name="viewport" content="width=device-width,initial-scale=1"/>
-<title>Schelling Game</title>
+<title>The Schelling Game</title>
 <link rel="preconnect" href="https://fonts.googleapis.com"/>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
 <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;0,700;1,400&family=Outfit:wght@300;400;500;600&display=swap" rel="stylesheet"/>
@@ -592,7 +592,7 @@ footer{
     <div class="section-label reveal">The Rules</div>
     <h2 class="section-title reveal">What if winning meant<br/>agreeing with strangers?</h2>
     <p class="section-body reveal">
-      Schelling Game puts you in a room with other players. Everyone sees the same
+      The Schelling Game puts you in a room with other players. Everyone sees the same
       question. Everyone picks an answer alone. Those who converge on the most
       popular choice split the pot. The rest lose their ante.
     </p>

--- a/src/worker/session.ts
+++ b/src/worker/session.ts
@@ -20,7 +20,7 @@ export function buildChallengeMessage(
   issuedAt: number,
 ): string {
   return (
-    'Sign this message to authenticate with Schelling Game.' +
+    'Sign this message to authenticate with The Schelling Game.' +
     `\n\nWallet: ${walletAddress}\nNonce: ${nonce}\nIssued: ${issuedAt}`
   );
 }


### PR DESCRIPTION
## What changed
This updates the product naming to use `The Schelling Game` on formal title-facing surfaces while keeping the compact `Schelling Game` wordmark in place.

## Why
The branding decision was to keep the singular concept name and use the definite article for the canonical title form. This makes the product feel intentional and authoritative without forcing the UI logo to become longer.

## Impact
- Browser titles now use `The Schelling Game`
- Landing-page explanatory copy now uses `The Schelling Game`
- Wallet-signature auth challenges now reference `The Schelling Game`
- The canonical game-rules document now uses `The Schelling Game`

## Validation
- `npm test`
- `npm run typecheck`
- `npm run typecheck:worker`
- `npm run lint` currently fails because unrelated nested `biome.json` files exist under the untracked `.claude/worktrees/` directory
- `npx biome check public/index.html public/app.html src/worker/session.ts docs/game-design.md`