### PR TITLE
fix: add missing "The" prefix to visible logos

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -181,7 +181,7 @@ nav{display:flex;gap:.5rem}
 <body>
 <div id="app">
   <header>
-    <h1><a href="/" style="color:inherit;text-decoration:none">Schelling <span>Game</span></a></h1>
+    <h1><a href="/" style="color:inherit;text-decoration:none">The Schelling <span>Game</span></a></h1>
     <div id="header-profile" class="hidden">
       <span class="name" id="header-name"></span>
       <span class="bal" id="header-balance"></span>

--- a/public/index.html
+++ b/public/index.html
@@ -822,7 +822,7 @@ footer{
 <a href="#main-content" class="skip-link">Skip to main content</a>
 
 <nav aria-label="Primary navigation">
-  <div class="logo">Schelling <span>Game</span></div>
+  <div class="logo">The Schelling <span>Game</span></div>
   <a href="/app.html" class="play-link">Play</a>
 </nav>
 
@@ -1164,7 +1164,7 @@ footer{
 <footer>
   <div class="footer-inner">
     <div>
-      <div class="footer-brand">Schelling <span>Game</span></div>
+      <div class="footer-brand">The Schelling <span>Game</span></div>
       <div class="footer-desc">A coordination game based on focal point theory</div>
     </div>
     <div class="footer-links">


### PR DESCRIPTION
The branding commit (b491cd7) updated `<title>` tags to "The Schelling Game" but missed the three visible logo instances:

- `public/index.html` nav logo (top-left)
- `public/index.html` footer brand
- `public/app.html` header logo

All three now read "The Schelling Game" to match the title and overall branding.