### PR TITLE
docs: add missing links and new resources to Further Reading

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1091,29 +1091,31 @@ footer{
       <ul class="learn-reading-list">
         <li>
           Thomas Schelling &mdash;
-          <em>The Strategy of Conflict</em>
+          <a href="https://en.wikipedia.org/wiki/The_Strategy_of_Conflict" target="_blank" rel="noopener noreferrer"><em>The Strategy of Conflict</em></a>
           <span class="reading-year">1960</span>
         </li>
         <li>
           Mehta, Starmer &amp; Sugden &mdash;
-          <a href="https://www.jstor.org/stable/2118026" target="_blank" rel="noopener">"The Nature of Salience: An Experimental Investigation"</a>
+          <a href="https://www.jstor.org/stable/2118026" target="_blank" rel="noopener noreferrer">"The Nature of Salience: An Experimental Investigation"</a>
           <span class="reading-year">1994</span>
         </li>
         <li>
           Vitalik Buterin &mdash;
-          SchellingCoin
+          <a href="https://blog.ethereum.org/2014/03/28/schellingcoin-a-minimal-trust-universal-data-feed" target="_blank" rel="noopener noreferrer">SchellingCoin</a>
           <span class="reading-year">2014</span>
         </li>
         <li>
-          Augur
+          <a href="https://augur.net" target="_blank" rel="noopener noreferrer">Augur</a>
           &mdash; Schelling games for prediction markets
+          <span class="reading-year">2015</span>
         </li>
         <li>
-          <a href="https://kleros.io/whitepaper.pdf" target="_blank" rel="noopener">Kleros Whitepaper</a>
+          <a href="https://kleros.io/whitepaper.pdf" target="_blank" rel="noopener noreferrer">Kleros Whitepaper</a>
           &mdash; commit-reveal voting for decentralized dispute resolution
+          <span class="reading-year">2019</span>
         </li>
         <li>
-          <a href="https://blog.ethereum.org/2015/01/28/p-epsilon-attack" target="_blank" rel="noopener">P+&epsilon; Attack</a>
+          <a href="https://blog.ethereum.org/2015/01/28/p-epsilon-attack" target="_blank" rel="noopener noreferrer">P+&epsilon; Attack</a>
           &mdash; a known bribery vulnerability in Schelling-point mechanisms
           <span class="reading-year">2015</span>
         </li>


### PR DESCRIPTION
## Summary

Narrowly scoped fix for the three missing links in the Further Reading section, plus metadata consistency.

### Changes
- Link The Strategy of Conflict to Wikipedia
- Link SchellingCoin to Ethereum blog post  
- Link Augur to augur.net and add reading-year span (2015)
- Add reading-year span to Kleros (2019) so every entry has consistent metadata
- Harden existing links with rel="noopener noreferrer"

### What this PR does NOT do
Additional reading list entries (Myerson, Truthcoin, UMA, AI Alignment Forum) are deferred to a follow-up issue to keep this PR minimal.

### Test plan
- Open the landing page and expand Further Reading
- Verify all 6 entries have working links that open in new tabs
- Verify Augur shows (2015) and Kleros shows (2019)
- Confirm no separators or entry order changed

Closes #155
