### PR TITLE
docs: expand Further Reading with additional resources

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1100,8 +1100,18 @@ footer{
           <span class="reading-year">1994</span>
         </li>
         <li>
+          Roger Myerson &mdash;
+          <a href="https://home.uchicago.edu/~rmyerson/stratofc2010.pdf" target="_blank" rel="noopener noreferrer">"Learning from Schelling's Strategy of Conflict"</a>
+          <span class="reading-year">2010</span>
+        </li>
+        <li>
           Vitalik Buterin &mdash;
           <a href="https://blog.ethereum.org/2014/03/28/schellingcoin-a-minimal-trust-universal-data-feed" target="_blank" rel="noopener noreferrer">SchellingCoin</a>
+          <span class="reading-year">2014</span>
+        </li>
+        <li>
+          Paul Sztorc &mdash;
+          <a href="https://www.truthcoin.info/papers/truthcoin-whitepaper.pdf" target="_blank" rel="noopener noreferrer">"Truthcoin" whitepaper</a>
           <span class="reading-year">2014</span>
         </li>
         <li>
@@ -1110,14 +1120,24 @@ footer{
           <span class="reading-year">2015</span>
         </li>
         <li>
+          <a href="https://blog.ethereum.org/2015/01/28/p-epsilon-attack" target="_blank" rel="noopener noreferrer">P+&epsilon; Attack</a>
+          &mdash; a known bribery vulnerability in Schelling-point mechanisms
+          <span class="reading-year">2015</span>
+        </li>
+        <li>
           <a href="https://kleros.io/whitepaper.pdf" target="_blank" rel="noopener noreferrer">Kleros Whitepaper</a>
           &mdash; commit-reveal voting for decentralized dispute resolution
           <span class="reading-year">2019</span>
         </li>
         <li>
-          <a href="https://blog.ethereum.org/2015/01/28/p-epsilon-attack" target="_blank" rel="noopener noreferrer">P+&epsilon; Attack</a>
-          &mdash; a known bribery vulnerability in Schelling-point mechanisms
-          <span class="reading-year">2015</span>
+          <a href="https://docs.uma.xyz" target="_blank" rel="noopener noreferrer">UMA Optimistic Oracle</a>
+          &mdash; Schelling-point dispute resolution in production DeFi
+          <span class="reading-year">2020</span>
+        </li>
+        <li>
+          AI Alignment Forum &mdash;
+          <a href="https://www.alignmentforum.org/posts/n2c62YS8RJtD4Aqhh/schelling-game-evaluations-for-ai-control" target="_blank" rel="noopener noreferrer">"Schelling game evaluations for AI control"</a>
+          <span class="reading-year">2024</span>
         </li>
       </ul>
     </details>


### PR DESCRIPTION
## Summary

Add four new entries to the Further Reading section, spanning theory through applied Schelling mechanisms:

| Entry | Year | Why it fits |
|---|---|---|
| Roger Myerson - "Learning from Schelling's Strategy of Conflict" | 2010 | Nobel-level retrospective, freely available PDF |
| Paul Sztorc - "Truthcoin" whitepaper | 2014 | Pre-Augur formalization of on-chain Schelling games |
| UMA Optimistic Oracle | 2020 | Schelling-point dispute resolution in production DeFi |
| AI Alignment Forum - "Schelling game evaluations for AI control" | 2024 | Connects Schelling games to LLM/AI safety |

Also reorders existing entries into strict chronological order (P+epsilon 2015 now before Kleros 2019).

### Format
All new entries follow the existing patterns:
- Author-led: `Author &mdash; <linked title> <year>`
- Link-led: `<linked title> &mdash; description <year>`

### Test plan
- Open the landing page and expand Further Reading
- Verify all 10 entries are present with working links
- Confirm chronological order: 1960, 1994, 2010, 2014, 2014, 2015, 2015, 2019, 2020, 2024
- Each link opens in a new tab

Closes #157