### PR TITLE
config: enable AI bot in production

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -14,6 +14,14 @@ database_name = "schelling-game-db"
 database_id = "ccf25d5a-0c4e-4520-9e08-e3f2a02b78d1"
 migrations_dir = "d1-migrations"
 
+[ai]
+binding = "AI"
+
+[vars]
+AI_BOT_ENABLED = "true"
+AI_BOT_MODEL = "@cf/meta/llama-3.2-3b-instruct"
+AI_BOT_TIMEOUT_MS = "2500"
+
 [env.staging]
 name = "schelling-game-staging"
 


### PR DESCRIPTION
## Summary

Enable the production Worker's top-level `AI` binding and bot env vars so the AI backfill player remains enabled on future deploys from `main`.

## Changes

- add top-level `[ai]` binding for production
- add top-level `[vars]` for `AI_BOT_ENABLED`, `AI_BOT_MODEL`, and `AI_BOT_TIMEOUT_MS`
- leave the existing `staging` environment unchanged

## Why

Production was manually deployed with the AI binding enabled, but without this config committed to `main`, the next normal deploy from GitHub Actions would turn the bot off again.