### PR TITLE
feat: upgrade AI bot to nemotron-3-120b and use model name as display name

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -75,9 +75,8 @@ const MAX_MATCH_SIZE = 21;
 const MIN_MATCH_SIZE = 3;
 const STALE_MATCH_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
 const AI_BOT_ACCOUNT_PREFIX = 'ai-bot:';
-const AI_BOT_DISPLAY_NAME = 'AI Backfill';
-const DEFAULT_AI_BOT_MODEL = '@cf/meta/llama-3.2-3b-instruct';
-const DEFAULT_AI_BOT_TIMEOUT_MS = 2_500;
+const DEFAULT_AI_BOT_MODEL = '@cf/nvidia/nemotron-3-120b-a12b';
+const DEFAULT_AI_BOT_TIMEOUT_MS = 5_000;
 const AI_BOT_COMMIT_BUFFER_MS = 1_500;
 
 function buildAllowedMatchSizes(availablePlayers: number): number[] {
@@ -359,9 +358,15 @@ export class GameRoom {
     return `${AI_BOT_ACCOUNT_PREFIX}${crypto.randomUUID()}`;
   }
 
+  _getAiBotDisplayName(): string {
+    const model = this._getAiBotModel();
+    const lastSegment = model.split('/').pop() || model;
+    return lastSegment;
+  }
+
   _getDisplayName(accountId: string): string {
     if (this._isAiBot(accountId)) {
-      return AI_BOT_DISPLAY_NAME;
+      return this._getAiBotDisplayName();
     }
     return this.connections.get(accountId)?.displayName || 'unknown';
   }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -20,8 +20,8 @@ remote = true
 
 [vars]
 AI_BOT_ENABLED = "true"
-AI_BOT_MODEL = "@cf/meta/llama-3.2-3b-instruct"
-AI_BOT_TIMEOUT_MS = "2500"
+AI_BOT_MODEL = "@cf/nvidia/nemotron-3-120b-a12b"
+AI_BOT_TIMEOUT_MS = "5000"
 
 [env.staging]
 name = "schelling-game-staging"
@@ -42,8 +42,8 @@ remote = true
 
 [env.staging.vars]
 AI_BOT_ENABLED = "true"
-AI_BOT_MODEL = "@cf/meta/llama-3.2-3b-instruct"
-AI_BOT_TIMEOUT_MS = "2500"
+AI_BOT_MODEL = "@cf/nvidia/nemotron-3-120b-a12b"
+AI_BOT_TIMEOUT_MS = "5000"
 
 [assets]
 directory = "./public"


### PR DESCRIPTION
## Summary

- Switch default model from `llama-3.2-3b-instruct` (3B) to `nvidia/nemotron-3-120b-a12b` (MoE: 120B total, 12B active per token); should be comparable latency to the 3B but dramatically better at focal-point reasoning
- Increase timeout from 2.5s to 5s to give the larger model headroom
- Bot display name is now derived from the model identifier (e.g. `nemotron-3-120b-a12b`) instead of hardcoded "AI Backfill"

## Changes

- **worker.ts**: new default model, removed `AI_BOT_DISPLAY_NAME` constant, added `_getAiBotDisplayName()` that extracts the last segment of the model path
- **wrangler.toml**: updated both production and staging `AI_BOT_MODEL` and `AI_BOT_TIMEOUT_MS`