### PR TITLE
[codex] fix CSP websocket allowlist

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -4,4 +4,4 @@
   X-Frame-Options: DENY
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; connect-src 'self' wss://schelling.games ws://localhost:* https://api.github.com; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; connect-src 'self' wss: ws://localhost:* ws://127.0.0.1:* https://api.github.com; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; upgrade-insecure-requests

--- a/test/domain/csp-headers.test.ts
+++ b/test/domain/csp-headers.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const headersFile = readFileSync(
+  new URL('../../public/_headers', import.meta.url),
+  'utf8',
+);
+
+const contentSecurityPolicy = headersFile
+  .split('\n')
+  .find((line) => line.includes('Content-Security-Policy:'));
+
+describe('asset CSP', () => {
+  it('allows secure websockets across deployment hosts while keeping local dev explicit', () => {
+    expect(contentSecurityPolicy).toContain("connect-src 'self' wss:");
+    expect(contentSecurityPolicy).toContain('ws://localhost:*');
+    expect(contentSecurityPolicy).toContain('ws://127.0.0.1:*');
+    expect(contentSecurityPolicy).toContain('https://api.github.com');
+    expect(contentSecurityPolicy).not.toContain('wss://schelling.games');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #162.

The static CSP in `public/_headers` only allowed `wss://schelling.games`, while the client opens its WebSocket against the current host. That caused CSP failures on alternate hosts such as `127.0.0.1` and any non-production deployment hostname.

This change updates `connect-src` to allow secure WebSockets via `wss:` across deployment hosts, while keeping insecure WebSockets limited to explicit local development hosts. It also adds a regression test that asserts the CSP stays aligned with same-host WebSocket behavior.

## Validation

- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run typecheck:worker`