### PR TITLE
Fix sitemap namespace

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://schelling.games/</loc>
     <lastmod>2026-03-28</lastmod>


### PR DESCRIPTION
## Summary
- switch `public/sitemap.xml` to the standard sitemap namespace URI
- keep the sitemap content unchanged otherwise

## Testing
- not run (static XML-only change)

Fixes #161