### PR TITLE
Document LLM coordination reading and isolate AI bot analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,15 @@ Prototype commit-reveal coordination game.
 The canonical game rules and design live in [docs/game-design.md](docs/game-design.md). It describes the game's core logic, match flow, commit-reveal rules, settlement, coordination credit, and question design policy.
 
 Architectural rationale is logged in [docs/adr/README.md](docs/adr/README.md).
+
+## Further Reading
+
+- [Schelling Coordination in LLMs: A Review](https://www.lesswrong.com/posts/tJKNXCxx7ZKD5mtG9/schelling-coordination-in-llms-a-review) for a useful survey of toy-task coordination, covert-channel risk, and why deployment context matters more than isolated coordination scores.
+- [Secret Collusion among AI Agents: Multi-Agent Deception via Steganography](https://arxiv.org/abs/2402.07510) for the underlying steganography and covert-collusion evaluation framework cited by the review.
+- [Subversion via Focal Points: Investigating Collusion in LLM Monitoring](https://arxiv.org/abs/2507.03010) for a more deployment-shaped evaluation of focal-point collusion in monitoring setups.
+
+Use the underlying papers, not only the LessWrong summary, when making concrete product or threat-model decisions.
+
+## LLM Usage Note
+
+This repo's optional Workers AI backfill bot is a queue-fill/testing aid, not canonical evidence about human focal points. Keep bot-influenced matches separate from question-pool calibration and any claims about human coordination quality.

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -866,36 +866,38 @@ export class GameRoom {
           }
         }
 
-        stmts.push(
-          this.env.DB.prepare(
-            'INSERT INTO vote_logs (match_id, game_number, question_id, account_id, display_name_snapshot, ' +
-              'revealed_option_index, revealed_option_label, won_game, earns_coordination_credit, ' +
-              'ante_amount, game_payout, net_delta, player_count, valid_reveal_count, top_count, ' +
-              'winner_count, winning_option_indexes_json, voided, void_reason, timestamp) ' +
-              'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
-          ).bind(
-            match.matchId,
-            match.currentGame,
-            question.id,
-            pr.accountId,
-            pr.displayName,
-            pr.revealedOptionIndex,
-            pr.revealedOptionLabel,
-            pr.wonGame ? 1 : 0,
-            pr.earnsCoordinationCredit ? 1 : 0,
-            pr.antePaid,
-            pr.gamePayout,
-            pr.netDelta,
-            result.playerCount,
-            result.validRevealCount,
-            result.topCount,
-            result.winnerCount,
-            JSON.stringify(result.winningOptionIndexes),
-            result.voided ? 1 : 0,
-            result.voidReason,
-            now,
-          ),
-        );
+        if (!this._isAiBot(pr.accountId)) {
+          stmts.push(
+            this.env.DB.prepare(
+              'INSERT INTO vote_logs (match_id, game_number, question_id, account_id, display_name_snapshot, ' +
+                'revealed_option_index, revealed_option_label, won_game, earns_coordination_credit, ' +
+                'ante_amount, game_payout, net_delta, player_count, valid_reveal_count, top_count, ' +
+                'winner_count, winning_option_indexes_json, voided, void_reason, timestamp) ' +
+                'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            ).bind(
+              match.matchId,
+              match.currentGame,
+              question.id,
+              pr.accountId,
+              pr.displayName,
+              pr.revealedOptionIndex,
+              pr.revealedOptionLabel,
+              pr.wonGame ? 1 : 0,
+              pr.earnsCoordinationCredit ? 1 : 0,
+              pr.antePaid,
+              pr.gamePayout,
+              pr.netDelta,
+              result.playerCount,
+              result.validRevealCount,
+              result.topCount,
+              result.winnerCount,
+              JSON.stringify(result.winningOptionIndexes),
+              result.voided ? 1 : 0,
+              result.voidReason,
+              now,
+            ),
+          );
+        }
       }
 
       if (stmts.length > 0) {
@@ -1232,20 +1234,10 @@ export class GameRoom {
       .map((option, index) => `${index}: ${option}`)
       .join('\n');
     return [
-      'You are playing a Schelling point coordination game.',
-      'All players see the same question and options. Nobody can communicate.',
-      'You win ONLY if you pick the same option as the majority.',
-      '',
-      'A Schelling point is the answer people gravitate to without talking:',
-      '- The most famous, default, or culturally dominant choice',
-      '- The first thing that comes to mind for most people',
-      '- Round numbers over odd ones (7 > 13, 100 > 67)',
-      '- The most stereotypical or cliche answer',
-      '',
-      'Think step by step:',
-      '1. What would the average person pick without overthinking?',
-      '2. Which option is the most obvious, common, or iconic?',
-      '3. Ignore what you personally prefer; pick what MOST people would pick.',
+      'You are filling one seat in a multiplayer coordination game.',
+      'Choose the option you expect the most human players in this match to choose.',
+      "Base the choice on an ordinary player's first instinct, not your personal preference.",
+      'Do not explain your reasoning.',
       '',
       `Question: ${question.text}`,
       'Options:',

--- a/test/worker/game-room-async.test.ts
+++ b/test/worker/game-room-async.test.ts
@@ -565,6 +565,87 @@ describe('GameRoom async task tracking', () => {
     if (match.revealTimer) clearTimeout(match.revealTimer);
   });
 
+  it('uses a plain backfill prompt instead of coaching the model into stronger Schelling behavior', () => {
+    const { room } = createRoom();
+    const prompt = room._buildAiBotPrompt({
+      id: 1,
+      text: 'Pick a color.',
+      type: 'select',
+      category: 'aesthetics',
+      options: ['Red', 'Blue', 'Green'],
+    });
+
+    expect(prompt).toContain('most human players');
+    expect(prompt).not.toContain('Think step by step');
+    expect(prompt).not.toContain('Round numbers over odd ones');
+  });
+
+  it('does not persist AI bot rows into vote_logs', async () => {
+    const prepare = vi.fn((sql: string) => ({
+      bind: (...args: unknown[]) => ({ sql, args }),
+    }));
+    const batch = vi.fn().mockResolvedValue(undefined);
+    const { room } = createRoom({
+      DB: { prepare, batch } as unknown as D1Database,
+    });
+    vi.spyOn(room, '_checkpointMatch').mockImplementation(() => {});
+    vi.spyOn(room, '_broadcastToMatch').mockImplementation(() => {});
+
+    const match = createMatch();
+    match.phase = 'reveal';
+    match.currentGame = 1;
+
+    match.players.set('acct-1', {
+      accountId: 'acct-1',
+      displayName: 'Alice',
+      ws: null,
+      startingBalance: 100,
+      currentBalance: 100,
+      committed: true,
+      revealed: true,
+      hash: createCommitHash(0, 'a'.repeat(64)),
+      optionIndex: 0,
+      salt: 'a'.repeat(64),
+      forfeited: false,
+      forfeitedAtGame: null,
+      disconnectedAt: null,
+      graceTimer: null,
+      pendingAiCommit: false,
+    });
+    match.players.set('ai-bot:test', {
+      accountId: 'ai-bot:test',
+      displayName: 'AI Backfill',
+      ws: null,
+      startingBalance: 0,
+      currentBalance: 0,
+      committed: true,
+      revealed: true,
+      hash: createCommitHash(1, 'b'.repeat(64)),
+      optionIndex: 1,
+      salt: 'b'.repeat(64),
+      forfeited: false,
+      forfeitedAtGame: null,
+      disconnectedAt: null,
+      graceTimer: null,
+      pendingAiCommit: false,
+    });
+
+    await room._finalizeGame(match);
+
+    const statements = must(
+      batch.mock.calls[0],
+      'Expected D1 batch call',
+    )[0] as Array<{ sql: string; args: unknown[] }>;
+    const voteLogStatements = statements.filter((stmt) =>
+      stmt.sql.startsWith('INSERT INTO vote_logs'),
+    );
+
+    expect(voteLogStatements).toHaveLength(1);
+    expect(voteLogStatements[0]?.args[3]).toBe('acct-1');
+
+    if (match.resultsTimer) clearTimeout(match.resultsTimer);
+  });
+
   it('continues the match when only an AI bot remains after settlement', async () => {
     vi.useFakeTimers();
 


### PR DESCRIPTION
## Summary
- add further reading on LLM Schelling coordination and document how to interpret it for this repo
- tone down the Workers AI backfill prompt so it behaves like plain queue fill instead of an explicitly coached Schelling solver
- exclude AI bot rows from durable `vote_logs` and add regression tests for the new prompt and logging policy

## Verification
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run typecheck:worker`