### PR TITLE
[codex] Add unanimous start-now voting for forming matches

### DIFF
--- a/docs/adr/0007-unanimous-start-now-for-forming-public-matches.md
+++ b/docs/adr/0007-unanimous-start-now-for-forming-public-matches.md
@@ -1,0 +1,33 @@
+# ADR 0007: Unanimous start-now override for forming public matches
+
+Status: Accepted
+Date: 2026-03-29
+
+## Context
+
+ADR `0006` kept a fill timer so public matches could keep growing toward larger odd lobbies, but that created dead time when a coordinated group was already present and wanted to begin immediately.
+
+The public queue still benefits from a fill window by default:
+
+- it preserves the ability to grow beyond the minimum `3` players
+- it gives late arrivals a chance to join the current public match
+- it keeps bot backfill from forcing fast bot matches on humans who would rather wait
+
+At the same time, a group of humans already inside the current forming match should be able to opt out of the rest of the wait explicitly.
+
+## Decision
+
+Public matchmaking keeps the fill timer from ADR `0006`, with one override:
+
+- each human player in the current forming public match may cast a `start now` vote
+- bots do not vote and do not block the override
+- if every human in that current forming match has voted `start now`, and the reserved player count is already a valid odd public match size, the match starts immediately
+- if the reserved count is even, unanimous `start now` votes remain armed but do not launch until the reserved count becomes odd or the normal fill timer path resolves the lobby
+- `start now` votes are scoped to the current queue entry and reset when a player leaves the queue, disconnects out of queue, is removed from the forming cohort, or starts a match
+
+## Consequences
+
+- coordinated groups can skip unnecessary idle time without removing the public fill window for everyone else
+- the product keeps growing public lobbies by default instead of collapsing into immediate `3`-player starts
+- even-sized ready groups still obey the odd-lobby rule, so unanimity does not bypass the plurality-size constraint
+- queue UI and websocket payloads must expose start-now readiness so humans can see when unanimity is close

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -18,3 +18,4 @@ Format:
 | [0004](./0004-remove-anti-pre-revelation-betting-from-v1.md) | Remove anti-pre-revelation betting from v1 | Accepted | 2026-03-23 |
 | [0005](./0005-moderated-leaderboard-and-coordination-credit.md) | Moderated leaderboard and coordination credit | Accepted | 2026-03-23 |
 | [0006](./0006-generalize-public-match-sizes.md) | Generalize public match sizes to odd counts up to 21 | Accepted | 2026-03-27 |
+| [0007](./0007-unanimous-start-now-for-forming-public-matches.md) | Unanimous start-now override for forming public matches | Accepted | 2026-03-29 |

--- a/public/app.html
+++ b/public/app.html
@@ -77,7 +77,24 @@ nav{display:flex;gap:.5rem}
 #queue-view .card{max-width:520px;margin:0 auto}
 #queue-players{list-style:none;display:flex;flex-wrap:wrap;gap:.5rem;margin:.75rem 0}
 #queue-players li{background:var(--surface2);border:1px solid var(--border);border-radius:2px;padding:.2rem .75rem;font-size:.8rem;letter-spacing:.04em}
-#forming-banner{background:rgba(255,152,0,.1);border:1px solid var(--orange);border-radius:var(--radius);padding:.6rem 1rem;font-size:.9rem;color:var(--orange);text-align:center;margin-top:.75rem}
+#forming-banner{display:flex;flex-direction:column;gap:.9rem;background:linear-gradient(135deg,rgba(201,168,76,.08),rgba(255,152,0,.06));border:1px solid rgba(201,168,76,.35);border-radius:var(--radius);padding:.9rem 1rem;margin-top:.75rem;color:var(--text);transition:border-color .2s ease,background .2s ease,transform .2s ease}
+#forming-banner.is-armed{border-color:rgba(201,168,76,.7);background:linear-gradient(135deg,rgba(201,168,76,.14),rgba(255,152,0,.08));transform:translateY(-1px)}
+.forming-banner-head{display:flex;align-items:flex-start;justify-content:space-between;gap:1rem;flex-wrap:wrap}
+.forming-kicker{font-size:.68rem;font-weight:600;letter-spacing:.18em;text-transform:uppercase;color:var(--accent)}
+.forming-title{font-size:1rem;line-height:1.25}
+.forming-title strong{font-family:var(--serif);font-size:1.4rem;font-weight:700;color:var(--accent2);margin-right:.3rem}
+.forming-timer-block{display:flex;align-items:baseline;gap:.45rem;white-space:nowrap;font-size:.82rem;color:var(--muted)}
+.forming-timer-block strong{font-family:var(--serif);font-size:1.35rem;line-height:1;color:var(--accent2)}
+.forming-banner-foot{display:flex;align-items:flex-end;justify-content:space-between;gap:.85rem;flex-wrap:wrap}
+.forming-readiness{display:flex;flex-direction:column;gap:.1rem;max-width:27rem}
+#start-now-meta{font-size:.76rem;font-weight:600;letter-spacing:.14em;text-transform:uppercase;color:var(--text)}
+#start-now-note{font-size:.8rem;color:var(--muted);line-height:1.45}
+#start-now-btn{min-width:170px}
+#start-now-btn[aria-pressed='true']{border-color:var(--accent);color:var(--accent);background:rgba(201,168,76,.08)}
+@media(max-width:560px){
+  .forming-banner-foot{align-items:stretch}
+  #start-now-btn{width:100%}
+}
 .toggle-row{display:flex;align-items:center;gap:.5rem;font-size:.85rem;color:var(--muted);margin-top:.75rem}
 .toggle-row input[type=checkbox]{width:auto;accent-color:var(--accent)}
 /* Play */
@@ -271,8 +288,23 @@ nav{display:flex;gap:.5rem}
       <div style="font-size:.9rem;color:var(--muted)">Players in queue: <strong id="queue-count">0</strong></div>
       <ul id="queue-players"></ul>
       <div id="forming-banner" class="hidden">
-        Match forming: <strong id="forming-count">0</strong> players reserved.
-        Fill closes in <strong id="forming-timer">--</strong>s
+        <div class="forming-banner-head">
+          <div>
+            <div class="forming-kicker">Forming Match</div>
+            <div class="forming-title"><strong id="forming-count">0</strong> players reserved</div>
+          </div>
+          <div class="forming-timer-block">
+            <span>Fill closes in</span>
+            <strong id="forming-timer">--</strong>s
+          </div>
+        </div>
+        <div class="forming-banner-foot">
+          <div class="forming-readiness">
+            <span id="start-now-meta">0 / 0 humans ready to start</span>
+            <span id="start-now-note">When every human in this forming match votes yes, the match launches immediately.</span>
+          </div>
+          <button class="btn-ghost hidden" id="start-now-btn" type="button" aria-pressed="false">Vote Start Now</button>
+        </div>
       </div>
       <div class="action-row">
         <button class="btn-primary hidden" id="return-to-game-btn">Back to Game</button>
@@ -508,6 +540,7 @@ const S = {
   tokenBalance: 0,
   autoRequeue: true,
   aiAssistedMatch: false,
+  startNow: false,
   // queue
   inQueue: false,
   queuedPlayers: [],
@@ -1011,12 +1044,16 @@ function syncAiAssistedUi() {
 $('#join-queue-btn').addEventListener('click', () => {
   wsSend({ type: 'join_queue' });
   S.autoRequeue = true;
+  S.startNow = false;
+  syncStartNowUI();
   syncAutoRequeueUI();
 });
 
 $('#leave-queue-btn').addEventListener('click', () => {
   wsSend({ type: 'leave_queue' });
   S.autoRequeue = false;
+  S.startNow = false;
+  syncStartNowUI();
   syncAutoRequeueUI();
 });
 
@@ -1032,18 +1069,36 @@ $('#auto-requeue-toggle').addEventListener('change', (e) => {
   // auto-requeue is session state; toggling while not queued is just a preference
 });
 
+$('#start-now-btn').addEventListener('click', () => {
+  const nextValue = !S.startNow;
+  S.startNow = nextValue;
+  syncStartNowUI();
+  wsSend({ type: 'set_start_now', value: nextValue });
+});
+
 function syncAutoRequeueUI() {
   $('#auto-requeue-toggle').checked = S.autoRequeue;
   $('#summary-auto-requeue').checked = S.autoRequeue;
 }
 
+function syncStartNowUI() {
+  const btn = $('#start-now-btn');
+  btn.setAttribute('aria-pressed', S.startNow ? 'true' : 'false');
+  btn.textContent = S.startNow ? 'Ready to Start' : 'Vote Start Now';
+}
+
 function onQueueState(msg) {
-  S.inQueue = msg.status === 'queued';
+  S.inQueue = msg.status === 'queued' || msg.status === 'forming';
   S.queuedPlayers = msg.queuedPlayers || [];
   S.formingMatch = msg.formingMatch || null;
   if (msg.autoRequeue !== undefined) {
     S.autoRequeue = msg.autoRequeue;
     syncAutoRequeueUI();
+  }
+  if (msg.startNow !== undefined) {
+    S.startNow = msg.startNow;
+  } else if (!S.formingMatch) {
+    S.startNow = false;
   }
   updateNavigation();
 
@@ -1073,9 +1128,26 @@ function renderQueue() {
   if (S.formingMatch) {
     $('#forming-banner').classList.remove('hidden');
     $('#forming-count').textContent = S.formingMatch.playerCount;
+    const readyCount = S.formingMatch.readyHumanCount || 0;
+    const humanCount = S.formingMatch.humanPlayerCount || 0;
+    const oddSized = S.formingMatch.playerCount % 2 === 1;
+    $('#start-now-meta').textContent = readyCount + ' / ' + humanCount + ' humans ready to start';
+    let note = 'When every human in this forming match votes yes, the match launches immediately.';
+    if (!oddSized) {
+      note = 'Start now arms the lobby now, but launch still waits for an odd reserved count.';
+    } else if (S.startNow) {
+      note = 'Your vote is in. The match starts as soon as every other human votes yes.';
+    }
+    $('#start-now-note').textContent = note;
+    $('#forming-banner').classList.toggle('is-armed', oddSized && readyCount > 0);
+    $('#start-now-btn').classList.toggle('hidden', !S.formingMatch.youCanVoteStartNow);
+    syncStartNowUI();
     updateFormingTimer();
   } else {
     $('#forming-banner').classList.add('hidden');
+    $('#forming-banner').classList.remove('is-armed');
+    S.startNow = false;
+    syncStartNowUI();
   }
 
   // buttons
@@ -1103,6 +1175,7 @@ function onMatchStarted(msg) {
   S.matchId = msg.matchId;
   S.aiAssistedMatch = !!msg.aiAssisted;
   S.inQueue = false;
+  S.startNow = false;
   S.queuedPlayers = [];
   S.formingMatch = null;
   S.players = msg.players;
@@ -1857,6 +1930,8 @@ function quoteLabel(label) {
 
 $('#requeue-btn').addEventListener('click', () => {
   S.autoRequeue = true;
+  S.startNow = false;
+  syncStartNowUI();
   syncAutoRequeueUI();
   wsSend({ type: 'join_queue' });
   showView('queue');

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -5,6 +5,7 @@ import type { GameResultWithBalances, Question } from './domain';
 export type ClientMessage =
   | { type: 'join_queue' }
   | { type: 'leave_queue' }
+  | { type: 'set_start_now'; value: boolean }
   | { type: 'commit'; hash: string }
   | { type: 'reveal'; optionIndex: number; salt: string }
   | { type: 'question_rating'; rating: 'like' | 'dislike' };
@@ -17,11 +18,15 @@ export interface QueueStateMessage {
   queuedCount: number;
   queuedPlayers: string[];
   autoRequeue?: boolean;
+  startNow?: boolean;
   formingMatch: {
     playerCount: number;
+    humanPlayerCount: number;
+    readyHumanCount: number;
     players: string[];
     allowedSizes: number[];
-    fillDeadlineMs: number;
+    fillDeadlineMs: number | null;
+    youCanVoteStartNow: boolean;
   } | null;
 }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -43,6 +43,7 @@ interface ConnectionState {
   ws: WebSocket;
   displayName: string;
   autoRequeue: boolean;
+  startNow: boolean;
   previousOpponents: Set<string>;
 }
 
@@ -242,6 +243,7 @@ export class GameRoom {
             ws,
             displayName,
             autoRequeue: false,
+            startNow: false,
             previousOpponents: new Set(),
           });
           if (playerState.graceTimer) {
@@ -294,6 +296,7 @@ export class GameRoom {
       ws,
       displayName,
       autoRequeue: false,
+      startNow: false,
       previousOpponents: existingConn
         ? existingConn.previousOpponents
         : new Set(),
@@ -348,6 +351,8 @@ export class GameRoom {
         return this._handleJoinQueue(accountId);
       case 'leave_queue':
         return this._handleLeaveQueue(accountId);
+      case 'set_start_now':
+        return this._handleSetStartNow(accountId, msg);
       case 'commit':
         return this._handleCommit(accountId, msg);
       case 'reveal':
@@ -437,6 +442,40 @@ export class GameRoom {
       }
     }
     return count;
+  }
+
+  _getFormingHumanIds(): string[] {
+    if (!this.formingMatch) return [];
+    return this.formingMatch.players.filter(
+      (accountId) => !this._isAiBot(accountId),
+    );
+  }
+
+  _clearStartNowFlags(accountIds: string[]): void {
+    for (const accountId of accountIds) {
+      if (this._isAiBot(accountId)) continue;
+      const conn = this.connections.get(accountId);
+      if (conn) conn.startNow = false;
+    }
+  }
+
+  _allFormingHumansWantStartNow(): boolean {
+    const humanIds = this._getFormingHumanIds();
+    if (humanIds.length === 0) return false;
+
+    return humanIds.every(
+      (accountId) => this.connections.get(accountId)?.startNow,
+    );
+  }
+
+  _tryStartReadyMatch(): boolean {
+    if (!this.formingMatch) return false;
+    if (this.formingMatch.players.length < MIN_MATCH_SIZE) return false;
+    if (this.formingMatch.players.length % 2 === 0) return false;
+    if (!this._allFormingHumansWantStartNow()) return false;
+
+    this._startFormingMatch();
+    return true;
   }
 
   _getQueuedAiBotIds(): string[] {
@@ -529,6 +568,7 @@ export class GameRoom {
     }
 
     conn.autoRequeue = true;
+    conn.startNow = false;
     this.waitingQueue.push(accountId);
     this._ensureAiBotBackfill();
     this._tryFormMatch();
@@ -540,9 +580,36 @@ export class GameRoom {
     if (!conn) return;
 
     conn.autoRequeue = false;
+    conn.startNow = false;
     this._removeFromQueue(accountId);
     this._ensureAiBotBackfill();
     this._tryFormMatch();
+    this._broadcastQueueState();
+  }
+
+  _handleSetStartNow(
+    accountId: string,
+    msg: { type: string; [key: string]: unknown },
+  ): void {
+    const conn = this.connections.get(accountId);
+    if (!conn) return;
+
+    if (typeof msg.value !== 'boolean') {
+      return this._sendTo(accountId, {
+        type: 'error',
+        message: 'start_now vote must be true or false',
+      });
+    }
+
+    if (!this.formingMatch?.players.includes(accountId)) {
+      return this._sendTo(accountId, {
+        type: 'error',
+        message: 'Start now is only available while your match is forming',
+      });
+    }
+
+    conn.startNow = msg.value;
+    if (this._tryStartReadyMatch()) return;
     this._broadcastQueueState();
   }
 
@@ -570,6 +637,7 @@ export class GameRoom {
 
     // Return remaining players to front of queue in their existing order
     const returning = this.formingMatch.players;
+    this._clearStartNowFlags(returning);
     this.waitingQueue.unshift(...returning);
     this.formingMatch = null;
   }
@@ -588,6 +656,8 @@ export class GameRoom {
       // If max reached, start immediately
       if (this.formingMatch.players.length >= MAX_MATCH_SIZE) {
         this._startFormingMatch();
+      } else {
+        this._tryStartReadyMatch();
       }
       return;
     }
@@ -610,10 +680,11 @@ export class GameRoom {
       return;
     }
 
-    // Start 20s fill timer
+    // Start 30s fill timer
     const fillDeadlineMs = Date.now() + FILL_TIMER_MS;
     const timer = setTimeout(() => this._onFillTimerExpired(), FILL_TIMER_MS);
     this.formingMatch = { players: reserved, timer, fillDeadlineMs };
+    this._tryStartReadyMatch();
   }
 
   _onFillTimerExpired(): void {
@@ -629,22 +700,29 @@ export class GameRoom {
     }
 
     const players = this.formingMatch.players;
+    let returnedToQueue: string[] = [];
 
     // Ensure odd count: take largest odd <= current size
     if (players.length % 2 === 0) {
       // Return the most recently reserved extra player(s) to front of queue
       const extras = players.splice(players.length - 1, 1);
+      returnedToQueue = extras;
+      this._clearStartNowFlags(extras);
       this.waitingQueue.unshift(...extras);
     }
 
     // Should still have at least 3
     if (players.length < MIN_MATCH_SIZE) {
+      this._clearStartNowFlags(players);
       this.waitingQueue.unshift(...players);
       this.formingMatch = null;
       this._tryFormMatch();
       this._broadcastQueueState();
       return;
     }
+
+    this._clearStartNowFlags(players);
+    this._clearStartNowFlags(returnedToQueue);
 
     const matchId = crypto.randomUUID();
     this.formingMatch = null;
@@ -1856,7 +1934,7 @@ export class GameRoom {
   }
 
   _buildQueueStateMsg(
-    _accountId: string,
+    accountId: string,
     isQueued: boolean,
     autoRequeue: boolean,
   ): Record<string, unknown> {
@@ -1869,22 +1947,32 @@ export class GameRoom {
 
     let formingMatch: {
       playerCount: number;
+      humanPlayerCount: number;
+      readyHumanCount: number;
       players: string[];
       allowedSizes: number[];
       fillDeadlineMs: number | null;
+      youCanVoteStartNow: boolean;
     } | null = null;
     const formingState = this.formingMatch;
     if (formingState) {
       const fmPlayers = formingState.players.map((id) =>
         this._getDisplayName(id),
       );
+      const humanIds = formingState.players.filter((id) => !this._isAiBot(id));
+      const readyHumanCount = humanIds.filter(
+        (id) => this.connections.get(id)?.startNow,
+      ).length;
       formingMatch = {
         playerCount: formingState.players.length,
+        humanPlayerCount: humanIds.length,
+        readyHumanCount,
         players: fmPlayers,
         allowedSizes: buildAllowedMatchSizes(
           formingState.players.length + this.waitingQueue.length,
         ),
         fillDeadlineMs: formingState.fillDeadlineMs,
+        youCanVoteStartNow: formingState.players.includes(accountId),
       };
     }
 
@@ -1892,6 +1980,7 @@ export class GameRoom {
       type: 'queue_state',
       status: isQueued ? 'queued' : 'idle',
       autoRequeue,
+      startNow: this.connections.get(accountId)?.startNow ?? false,
       queuedCount: allQueuedIds.length,
       queuedPlayers,
       formingMatch,

--- a/test/worker/game-room-async.test.ts
+++ b/test/worker/game-room-async.test.ts
@@ -49,6 +49,7 @@ function createConnectionState(displayName: string) {
     } as unknown as WebSocket,
     displayName,
     autoRequeue: false,
+    startNow: false,
     previousOpponents: new Set<string>(),
   };
 }
@@ -394,6 +395,107 @@ describe('GameRoom async task tracking', () => {
     expect(room.waitingQueue).toEqual(['acct-10']);
     expect(waitUntil).toHaveBeenCalledTimes(1);
     await must(waitUntil.mock.calls[0], 'Expected waitUntil call')[0];
+  });
+
+  it('starts immediately when all humans in an odd forming match vote start now', () => {
+    const { room } = createRoom();
+    const startFormingMatch = vi
+      .spyOn(room, '_startFormingMatch')
+      .mockImplementation(() => {});
+
+    room.connections.set('acct-1', createConnectionState('Alice'));
+    room.connections.set('acct-2', createConnectionState('Bob'));
+    room.connections.set('acct-3', createConnectionState('Carol'));
+    room.formingMatch = {
+      players: ['acct-1', 'acct-2', 'acct-3'],
+      timer: null,
+      fillDeadlineMs: Date.now() + 30_000,
+    };
+
+    room._handleSetStartNow('acct-1', { value: true });
+    room._handleSetStartNow('acct-2', { value: true });
+    expect(startFormingMatch).not.toHaveBeenCalled();
+
+    room._handleSetStartNow('acct-3', { value: true });
+    expect(startFormingMatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not start immediately on unanimous start-now votes for an even forming match', () => {
+    const { room } = createRoom();
+    const startFormingMatch = vi
+      .spyOn(room, '_startFormingMatch')
+      .mockImplementation(() => {});
+
+    room.connections.set('acct-1', createConnectionState('Alice'));
+    room.connections.set('acct-2', createConnectionState('Bob'));
+    room.connections.set('acct-3', createConnectionState('Carol'));
+    room.connections.set('acct-4', createConnectionState('Drew'));
+    room.formingMatch = {
+      players: ['acct-1', 'acct-2', 'acct-3', 'acct-4'],
+      timer: null,
+      fillDeadlineMs: Date.now() + 30_000,
+    };
+
+    room._handleSetStartNow('acct-1', { value: true });
+    room._handleSetStartNow('acct-2', { value: true });
+    room._handleSetStartNow('acct-3', { value: true });
+    room._handleSetStartNow('acct-4', { value: true });
+
+    expect(startFormingMatch).not.toHaveBeenCalled();
+  });
+
+  it('includes start-now readiness data in queue state', () => {
+    const { room } = createRoom();
+
+    room.connections.set('acct-1', createConnectionState('Alice'));
+    room.connections.set('acct-2', createConnectionState('Bob'));
+    room.connections.set('acct-3', createConnectionState('Carol'));
+    room.connections.set('acct-4', createConnectionState('Spectator'));
+
+    must(room.connections.get('acct-1'), 'Expected Alice connection').startNow =
+      true;
+    must(room.connections.get('acct-3'), 'Expected Carol connection').startNow =
+      true;
+
+    room.formingMatch = {
+      players: ['acct-1', 'acct-2', 'acct-3'],
+      timer: null,
+      fillDeadlineMs: Date.now() + 30_000,
+    };
+
+    const participantState = room._buildQueueStateMsg(
+      'acct-1',
+      true,
+      false,
+    ) as {
+      startNow: boolean;
+      formingMatch: {
+        humanPlayerCount: number;
+        readyHumanCount: number;
+        youCanVoteStartNow: boolean;
+      } | null;
+    };
+    const spectatorState = room._buildQueueStateMsg('acct-4', false, false) as {
+      startNow: boolean;
+      formingMatch: {
+        humanPlayerCount: number;
+        readyHumanCount: number;
+        youCanVoteStartNow: boolean;
+      } | null;
+    };
+
+    expect(participantState.startNow).toBe(true);
+    expect(participantState.formingMatch).toMatchObject({
+      humanPlayerCount: 3,
+      readyHumanCount: 2,
+      youCanVoteStartNow: true,
+    });
+    expect(spectatorState.startNow).toBe(false);
+    expect(spectatorState.formingMatch).toMatchObject({
+      humanPlayerCount: 3,
+      readyHumanCount: 2,
+      youCanVoteStartNow: false,
+    });
   });
 
   it('caps immediately formed public matches at 21 players', () => {


### PR DESCRIPTION
## Summary

Closes #180.

Add a unanimous `start now` override for forming public matches so coordinated groups can skip the remaining fill wait without removing the default fill-timer path for public queue growth.

## What Changed

- added a `set_start_now` websocket message and queue-state readiness fields
- tracked per-player `startNow` votes in the Durable Object queue state
- started forming matches immediately when every human in the current forming group voted yes and the reserved size was already odd
- updated the queue UI to show readiness counts and expose a single `Vote Start Now` control
- added async Worker tests for odd-size launch, even-size no-op, and readiness payloads
- recorded the matchmaking rule in ADR `0007`

## Why

The queue currently forces the full fill timer even when a pre-coordinated group is already present. That behavior is useful for public-lobby growth, but it creates unnecessary idle time for groups that explicitly want to begin now.

## Impact

- coordinated human groups can launch early by unanimous consent
- the existing fill timer still governs normal public queue growth
- even-sized reserved groups still respect the odd-match-size rule

## Validation

Passed:

- `npm run lint`
- `npm run typecheck`
- `npm run typecheck:worker`
- `npm test`

Attempted but did not complete in this environment:

- `npm run test:worker`