### PR TITLE
[codex] Demote off-record warning in game view

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -142,7 +142,10 @@ header .btn-ghost,header .button-link{padding:.48rem .78rem;font-size:.72rem;let
 @keyframes pulse{to{opacity:.3}}
 /* Question */
 #question-card{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:1.25rem}
-#phase-label{font-size:.7rem;font-weight:600;text-transform:uppercase;letter-spacing:.25em;margin-bottom:.5rem;color:var(--accent)}
+.question-meta-row{display:flex;align-items:flex-start;justify-content:space-between;gap:.75rem;flex-wrap:wrap;margin-bottom:.85rem}
+#phase-label{font-size:.7rem;font-weight:600;text-transform:uppercase;letter-spacing:.25em;margin:0;color:var(--accent)}
+#off-record-banner{display:inline-flex;align-items:flex-start;justify-content:flex-end;gap:.45rem;max-width:25rem;font-size:.72rem;line-height:1.45;color:var(--muted);text-align:right}
+#off-record-banner strong{font-size:.66rem;font-weight:600;letter-spacing:.16em;text-transform:uppercase;color:var(--accent2);white-space:nowrap}
 #question-text{font-family:var(--serif);font-size:1.4rem;font-weight:600;margin-bottom:1rem;line-height:1.3}
 #select-grid{display:grid;grid-template-columns:1fr 1fr;gap:.6rem}
 .opt-btn{background:var(--surface2);border:1px solid var(--border);border-radius:3px;padding:.75rem 1rem;cursor:pointer;text-align:left;font-family:var(--sans);font-size:.9rem;font-weight:400;color:var(--text);transition:border-color .2s,background .2s,color .2s;user-select:none}
@@ -293,6 +296,8 @@ header .btn-ghost,header .button-link{padding:.48rem .78rem;font-size:.72rem;let
   #start-now-btn{width:100%}
 }
 @media(max-width:560px){
+  .question-meta-row{margin-bottom:.7rem}
+  #off-record-banner{max-width:none;justify-content:flex-start;text-align:left}
   #summary-stats,#summary-highlights-grid{grid-template-columns:1fr}
 }
 @media(max-width:480px){
@@ -450,9 +455,12 @@ header .btn-ghost,header .button-link{padding:.48rem .78rem;font-size:.72rem;let
 
       <!-- Question -->
       <div id="question-card">
-        <div id="phase-label">Game <span id="game-num">1</span> / 10</div>
-        <div id="off-record-banner" class="info-banner hidden" style="margin-bottom:1rem">
-          <strong>Off the record.</strong> An AI backfill joined this match, so balances, streaks, and leaderboard standing will not change.
+        <div class="question-meta-row">
+          <div id="phase-label">Game <span id="game-num">1</span> / 10</div>
+          <div id="off-record-banner" class="hidden">
+            <strong>AI backfill</strong>
+            <span>This run is off the record, so balances and stats stay unchanged.</span>
+          </div>
         </div>
         <div id="forfeit-status-banner" class="danger-banner hidden" style="margin-bottom:1rem">
           <strong>Forfeit locked in.</strong> The rest of this run will settle without you. Final standings appear when the match closes.
@@ -1416,7 +1424,7 @@ function onMatchStarted(msg) {
   $('#commit-area').classList.add('hidden');
   $('#reveal-area').classList.add('hidden');
   if (S.aiAssistedMatch) {
-    notify('AI backfill joined this match. It is off the record: balances and stats will not change.', 'warn');
+    notify('AI backfill joined. This run is off the record.', '');
   } else {
     notify('Match started with ' + S.players.length + ' players', 'success');
   }


### PR DESCRIPTION
## What changed
- demoted the live AI backfill warning from a full info banner to quieter match metadata beside the game counter
- adjusted the off-record copy so it still communicates the rule without competing with the active question
- softened the AI-backfill toast to a neutral notice instead of a warning-style interruption

## Why
The off-record warning was sitting too high in the question card and pulling attention away from the actual decision surface. The game prompt should stay dominant, with match caveats present but secondary.

## Impact
Players still see when a match is off the record, but the question and choices regain visual priority during live play.

## Validation
- `npm run lint`
- `npm test`