### PR TITLE
chore: harden deploy hygiene

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    concurrency:
+      group: deploy-production
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v6
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,8 @@ node_modules/
 nohup.out
 .wrangler/
 .playwright-mcp/
+.mcp.json
+.dev.vars
+.env*
+*.bak
 .claude/settings.local.json

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "typecheck:worker": "tsc --noEmit -p tsconfig.worker.json",
     "stamp-build": "sed -i.bak -e \"s/__BUILD_HASH__/$(git rev-parse --short HEAD)/\" -e \"s/__BUILD_DATE__/$(date -u +%Y-%m-%dT%H:%MZ)/\" public/index.html public/app.html",
     "unstamp-build": "mv public/index.html.bak public/index.html && mv public/app.html.bak public/app.html",
-    "deploy": "npm run stamp-build && CLOUDFLARE_API_TOKEN=${CLOUDFLARE_FERIT_API_TOKEN:-$CLOUDFLARE_API_TOKEN} npx wrangler deploy && npm run unstamp-build"
+    "deploy": "sh -c 'set -e; cleanup(){ npm run unstamp-build >/dev/null 2>&1 || true; }; trap cleanup EXIT; npm run stamp-build; CLOUDFLARE_API_TOKEN=${CLOUDFLARE_FERIT_API_TOKEN:-$CLOUDFLARE_API_TOKEN} npx wrangler deploy; trap - EXIT; cleanup'"
   },
   "repository": {
     "type": "git",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,7 +1,7 @@
 name = "schelling-game"
 account_id = "abfb18f38d5263b5da582e40ba6ae552"
 main = "src/worker.ts"
-compatibility_date = "2024-12-01"
+compatibility_date = "2026-03-29"
 compatibility_flags = ["nodejs_compat"]
 
 [[durable_objects.bindings]]


### PR DESCRIPTION
## Summary
- Ignore local secret and backup artifacts in `.gitignore`
- Add production deploy concurrency control
- Ensure deploy cleanup runs on failure as well as success
- Bump the Workers compatibility date

Closes #207.