### PR TITLE
feat: harden auth/public-write validation and abuse controls

### DIFF
--- a/d1-migrations/0007_add_auth_challenge_expiry_index.sql
+++ b/d1-migrations/0007_add_auth_challenge_expiry_index.sql
@@ -1,0 +1,3 @@
+-- Speed up periodic cleanup of expired auth challenges.
+CREATE INDEX IF NOT EXISTS idx_auth_challenges_expires_at
+ON auth_challenges(expires_at);

--- a/src/worker/httpHandler.ts
+++ b/src/worker/httpHandler.ts
@@ -8,7 +8,6 @@ import type { Env } from '../types/worker-env';
 import {
   fetchAccountWithStats,
   fetchPlayerDOStatus,
-  type LeaderboardEntryInput,
   shapeLeaderboardEntry,
 } from './accountRepo';
 import {
@@ -20,9 +19,15 @@ import {
 } from './session';
 
 const DISPLAY_NAME_REGEX = /^[A-Za-z0-9_-]{1,20}$/;
+const WALLET_ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/;
+const SIGNATURE_REGEX = /^0x[a-fA-F0-9]{130}$/;
 const LANDING_STATS_CACHE_TTL_SECONDS = 60;
 const LANDING_STATS_CACHE_CONTROL = `public, max-age=${LANDING_STATS_CACHE_TTL_SECONDS}, s-maxage=${LANDING_STATS_CACHE_TTL_SECONDS}`;
 const LANDING_STATS_LOOKBACK_MS = 24 * 60 * 60 * 1000;
+const AUTH_CHALLENGE_CLEANUP_INTERVAL_MS = 60 * 1000;
+const AUTH_CHALLENGE_LIMIT = { max: 12, windowMs: 60 * 1000 };
+const AUTH_VERIFY_LIMIT = { max: 24, windowMs: 60 * 1000 };
+const EXAMPLE_VOTE_LIMIT = { max: 40, windowMs: 60 * 1000 };
 
 interface CacheStorageWithDefault extends CacheStorage {
   default?: Cache;
@@ -37,6 +42,14 @@ interface AuthChallengeRow {
   issued_at?: number | null;
 }
 
+interface RateLimitBucket {
+  windowStartedAt: number;
+  count: number;
+}
+
+const rateLimitBuckets = new Map<string, RateLimitBucket>();
+let nextAuthChallengeCleanupAt = 0;
+
 function jsonResponse(
   data: unknown,
   status = 200,
@@ -50,6 +63,14 @@ function jsonResponse(
 
 function errorResponse(message: string, status = 400): Response {
   return jsonResponse({ error: message }, status);
+}
+
+function rateLimitResponse(windowMs: number): Response {
+  return jsonResponse(
+    { error: 'Too many requests. Please try again later.' },
+    429,
+    { 'Retry-After': String(Math.ceil(windowMs / 1000)) },
+  );
 }
 
 function cookieAttrs(request: Request): string {
@@ -114,6 +135,128 @@ function parseIssuedAtFromChallengeMessage(message: string): number | null {
   const issuedAt = Number(match[1]);
   if (!Number.isSafeInteger(issuedAt)) return null;
   return issuedAt;
+}
+
+function getRequiredString(
+  body: Record<string, unknown>,
+  key: string,
+): string | null {
+  const value = body[key];
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+async function readJsonObjectBody(
+  request: Request,
+): Promise<Record<string, unknown> | Response> {
+  try {
+    const raw = await request.json();
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+      return errorResponse('Invalid JSON');
+    }
+    return raw as Record<string, unknown>;
+  } catch {
+    return errorResponse('Invalid JSON');
+  }
+}
+
+function normalizeWalletAddress(value: string): string | null {
+  if (!WALLET_ADDRESS_REGEX.test(value)) return null;
+  return value.toLowerCase();
+}
+
+function getClientIdentifier(request: Request): string {
+  const cfIp = request.headers.get('CF-Connecting-IP');
+  if (cfIp) return cfIp.trim();
+  const forwardedFor = request.headers.get('X-Forwarded-For');
+  if (forwardedFor) {
+    const first = forwardedFor.split(',')[0];
+    if (first) return first.trim();
+  }
+  return 'unknown';
+}
+
+function isRateLimited(
+  scope: string,
+  request: Request,
+  limit: { max: number; windowMs: number },
+): boolean {
+  const key = `${scope}:${getClientIdentifier(request)}`;
+  const now = Date.now();
+  const existing = rateLimitBuckets.get(key);
+  if (!existing || now - existing.windowStartedAt >= limit.windowMs) {
+    rateLimitBuckets.set(key, { windowStartedAt: now, count: 1 });
+    return false;
+  }
+
+  existing.count += 1;
+  if (existing.count > limit.max) {
+    return true;
+  }
+  return false;
+}
+
+async function maybeCleanupExpiredAuthChallenges(
+  db: D1Database,
+): Promise<void> {
+  const now = Date.now();
+  if (now < nextAuthChallengeCleanupAt) return;
+  nextAuthChallengeCleanupAt = now + AUTH_CHALLENGE_CLEANUP_INTERVAL_MS;
+
+  try {
+    await db
+      .prepare('DELETE FROM auth_challenges WHERE expires_at < ?')
+      .bind(new Date(now).toISOString())
+      .run();
+  } catch (error) {
+    console.error('D1: auth challenge cleanup failed', error);
+  }
+}
+
+function parseLeaderboardEntryRow(row: Record<string, unknown>): {
+  display_name: string | null;
+  token_balance: number;
+  leaderboard_eligible: number;
+  matches_played: number | null;
+  games_played: number | null;
+  coherent_games: number | null;
+  current_streak: number | null;
+  longest_streak: number | null;
+} | null {
+  const displayName = row.display_name;
+  if (!(displayName === null || typeof displayName === 'string')) return null;
+
+  const toNumber = (value: unknown): number | null => {
+    if (value === null || value === undefined) return null;
+    if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+    if (typeof value === 'string' && value.length > 0) {
+      const parsed = Number(value);
+      return Number.isFinite(parsed) ? parsed : null;
+    }
+    return null;
+  };
+
+  const tokenBalance = toNumber(row.token_balance);
+  const leaderboardEligible = toNumber(row.leaderboard_eligible);
+  const matchesPlayed = toNumber(row.matches_played);
+  const gamesPlayed = toNumber(row.games_played);
+  const coherentGames = toNumber(row.coherent_games);
+  const currentStreak = toNumber(row.current_streak);
+  const longestStreak = toNumber(row.longest_streak);
+
+  if (tokenBalance === null || leaderboardEligible === null) return null;
+
+  return {
+    display_name: displayName,
+    token_balance: tokenBalance,
+    leaderboard_eligible: leaderboardEligible,
+    matches_played: matchesPlayed,
+    games_played: gamesPlayed,
+    coherent_games: coherentGames,
+    current_streak: currentStreak,
+    longest_streak: longestStreak,
+  };
 }
 
 async function ensureAccountWithStats(
@@ -183,17 +326,22 @@ export async function handleHttpRequest(
 
   // ---- POST /api/auth/challenge ----
   if (url.pathname === '/api/auth/challenge' && method === 'POST') {
-    let body: { walletAddress?: string };
-    try {
-      body = await request.json();
-    } catch {
-      return errorResponse('Invalid JSON');
+    if (isRateLimited('auth_challenge', request, AUTH_CHALLENGE_LIMIT)) {
+      return rateLimitResponse(AUTH_CHALLENGE_LIMIT.windowMs);
     }
-    const walletAddress = body.walletAddress;
-    if (!walletAddress || typeof walletAddress !== 'string') {
+    await maybeCleanupExpiredAuthChallenges(env.DB);
+
+    const rawBody = await readJsonObjectBody(request);
+    if (rawBody instanceof Response) return rawBody;
+
+    const walletAddress = getRequiredString(rawBody, 'walletAddress');
+    if (!walletAddress) {
       return errorResponse('walletAddress required');
     }
-    const normalized = walletAddress.toLowerCase();
+    const normalized = normalizeWalletAddress(walletAddress);
+    if (!normalized) {
+      return errorResponse('walletAddress must be a valid 0x-prefixed address');
+    }
     const challengeId = `ch_${crypto.randomUUID()}`;
     const nonce = crypto.randomUUID();
     const issuedAt = Date.now();
@@ -215,23 +363,32 @@ export async function handleHttpRequest(
 
   // ---- POST /api/auth/verify ----
   if (url.pathname === '/api/auth/verify' && method === 'POST') {
-    let body: {
-      challengeId?: string;
-      walletAddress?: string;
-      signature?: string;
-    };
-    try {
-      body = await request.json();
-    } catch {
-      return errorResponse('Invalid JSON');
+    if (isRateLimited('auth_verify', request, AUTH_VERIFY_LIMIT)) {
+      return rateLimitResponse(AUTH_VERIFY_LIMIT.windowMs);
     }
-    const { challengeId, walletAddress, signature } = body;
+    await maybeCleanupExpiredAuthChallenges(env.DB);
+
+    const rawBody = await readJsonObjectBody(request);
+    if (rawBody instanceof Response) return rawBody;
+
+    const challengeId = getRequiredString(rawBody, 'challengeId');
+    const walletAddress = getRequiredString(rawBody, 'walletAddress');
+    const signature = getRequiredString(rawBody, 'signature');
     if (!challengeId || !walletAddress || !signature) {
       return errorResponse(
         'challengeId, walletAddress, and signature required',
       );
     }
-    const normalized = walletAddress.toLowerCase();
+    if (!challengeId.startsWith('ch_')) {
+      return errorResponse('challengeId format is invalid');
+    }
+    const normalized = normalizeWalletAddress(walletAddress);
+    if (!normalized) {
+      return errorResponse('walletAddress must be a valid 0x-prefixed address');
+    }
+    if (!SIGNATURE_REGEX.test(signature)) {
+      return errorResponse('signature format is invalid');
+    }
 
     const challenge = (await env.DB.prepare(
       'SELECT * FROM auth_challenges WHERE challenge_id = ? AND wallet_address = ?',
@@ -330,13 +487,10 @@ export async function handleHttpRequest(
     const accountId = await getAuthenticatedAccountId(request);
     if (!accountId) return errorResponse('Unauthorized', 401);
 
-    let body: { displayName?: string };
-    try {
-      body = await request.json();
-    } catch {
-      return errorResponse('Invalid JSON');
-    }
-    const displayName = body.displayName;
+    const rawBody = await readJsonObjectBody(request);
+    if (rawBody instanceof Response) return rawBody;
+
+    const displayName = getRequiredString(rawBody, 'displayName');
     if (!displayName || !DISPLAY_NAME_REGEX.test(displayName)) {
       return errorResponse('displayName must be 1-20 characters: A-Za-z0-9_-');
     }
@@ -378,12 +532,23 @@ export async function handleHttpRequest(
         `LIMIT ${LEADERBOARD_LIMIT}`,
     ).all();
 
-    const leaderboard = (results || []).map(
-      (r: Record<string, unknown>, i: number) => ({
+    const leaderboard = (results || [])
+      .map((r: Record<string, unknown>, i: number) => ({
         rank: i + 1,
-        ...shapeLeaderboardEntry(r as unknown as LeaderboardEntryInput),
-      }),
-    );
+        row: parseLeaderboardEntryRow(r),
+      }))
+      .filter(
+        (
+          row,
+        ): row is {
+          rank: number;
+          row: NonNullable<ReturnType<typeof parseLeaderboardEntryRow>>;
+        } => row.row !== null,
+      )
+      .map(({ rank, row }) => ({
+        rank,
+        ...shapeLeaderboardEntry(row),
+      }));
 
     return jsonResponse(leaderboard);
   }
@@ -557,24 +722,26 @@ export async function handleHttpRequest(
   if (url.pathname === '/api/admin/leaderboard-eligible' && method === 'POST') {
     const denied = await requireAdmin();
     if (denied) return denied;
-    let body: { accountId?: string; eligible?: boolean };
-    try {
-      body = await request.json();
-    } catch {
-      return errorResponse('Invalid JSON');
-    }
-    const { accountId, eligible } = body;
+    const rawBody = await readJsonObjectBody(request);
+    if (rawBody instanceof Response) return rawBody;
+
+    const accountId = getRequiredString(rawBody, 'accountId');
+    const eligible = rawBody.eligible;
     if (!accountId || typeof eligible !== 'boolean') {
       return errorResponse('accountId and eligible (boolean) required');
+    }
+    const normalizedAccountId = normalizeWalletAddress(accountId);
+    if (!normalizedAccountId) {
+      return errorResponse('accountId must be a valid 0x-prefixed address');
     }
     await env.DB.prepare(
       'UPDATE accounts SET leaderboard_eligible = ? WHERE account_id = ?',
     )
-      .bind(eligible ? 1 : 0, accountId.toLowerCase())
+      .bind(eligible ? 1 : 0, normalizedAccountId)
       .run();
 
     return jsonResponse({
-      accountId: accountId.toLowerCase(),
+      accountId: normalizedAccountId,
       leaderboardEligible: eligible,
     });
   }
@@ -589,13 +756,13 @@ export async function handleHttpRequest(
 
   // ---- POST /api/example-vote ----
   if (url.pathname === '/api/example-vote' && method === 'POST') {
-    let body: { optionIndex?: number };
-    try {
-      body = await request.json();
-    } catch {
-      return errorResponse('Invalid JSON');
+    if (isRateLimited('example_vote', request, EXAMPLE_VOTE_LIMIT)) {
+      return rateLimitResponse(EXAMPLE_VOTE_LIMIT.windowMs);
     }
-    const idx = body.optionIndex;
+    const rawBody = await readJsonObjectBody(request);
+    if (rawBody instanceof Response) return rawBody;
+
+    const idx = rawBody.optionIndex;
     if (
       typeof idx !== 'number' ||
       !Number.isInteger(idx) ||

--- a/test/worker/http-routes.test.ts
+++ b/test/worker/http-routes.test.ts
@@ -1,5 +1,5 @@
 import { env, exports } from 'cloudflare:workers';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { LEADERBOARD_LIMIT } from '../../src/domain/constants';
 import type { Env } from '../../src/types/worker-env';
 import { handleHttpRequest } from '../../src/worker/httpHandler';
@@ -334,6 +334,70 @@ describe('HTTP routes', () => {
     expect(data.expiresAt).toBeTruthy();
   });
 
+  it('POST /api/auth/challenge rejects malformed wallet addresses', async () => {
+    const resp = await post('/api/auth/challenge', {
+      walletAddress: 'not-a-wallet',
+    });
+    expect(resp.status).toBe(400);
+    const data = (await resp.json()) as { error: string };
+    expect(data.error).toContain('0x-prefixed address');
+  });
+
+  it('POST /api/auth/challenge rate limits repeated requests per IP', async () => {
+    const wallet = createTestWallet(20);
+    const headers = { 'CF-Connecting-IP': '203.0.113.205' };
+
+    let lastStatus = 0;
+    for (let i = 0; i < 13; i += 1) {
+      const resp = await post(
+        '/api/auth/challenge',
+        { walletAddress: wallet.address },
+        headers,
+      );
+      lastStatus = resp.status;
+    }
+
+    expect(lastStatus).toBe(429);
+  });
+
+  it('POST /api/auth/challenge opportunistically cleans up expired challenges', async () => {
+    const wallet = createTestWallet(21);
+    const now = Date.now();
+    const expiredChallengeId = 'ch_expired_cleanup_probe';
+    await env.DB.prepare(
+      'INSERT INTO auth_challenges (challenge_id, wallet_address, nonce, message, expires_at, issued_at) VALUES (?, ?, ?, ?, ?, ?)',
+    )
+      .bind(
+        expiredChallengeId,
+        wallet.address.toLowerCase(),
+        crypto.randomUUID(),
+        'expired',
+        new Date(now - 60_000).toISOString(),
+        now - 60_000,
+      )
+      .run();
+
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date(now + 5 * 60_000));
+      const challengeResp = await post(
+        '/api/auth/challenge',
+        { walletAddress: wallet.address },
+        { 'CF-Connecting-IP': '203.0.113.206' },
+      );
+      expect(challengeResp.status).toBe(200);
+    } finally {
+      vi.useRealTimers();
+    }
+
+    const stale = await env.DB.prepare(
+      'SELECT challenge_id FROM auth_challenges WHERE challenge_id = ?',
+    )
+      .bind(expiredChallengeId)
+      .first<{ challenge_id: string }>();
+    expect(stale).toBeNull();
+  });
+
   it('POST /api/auth/verify with valid signature sets session cookie', async () => {
     const wallet = createTestWallet(1);
     const normalized = wallet.address.toLowerCase();
@@ -405,6 +469,17 @@ describe('HTTP routes', () => {
     };
     expect(body.accountId).toBe(wallet.address.toLowerCase());
     expect(body.requiresDisplayName).toBe(true);
+  });
+
+  it('POST /api/auth/verify rejects malformed wallet addresses', async () => {
+    const resp = await post('/api/auth/verify', {
+      challengeId: 'ch_example',
+      walletAddress: 'not-a-wallet',
+      signature: `0x${'a'.repeat(130)}`,
+    });
+    expect(resp.status).toBe(400);
+    const data = (await resp.json()) as { error: string };
+    expect(data.error).toContain('0x-prefixed address');
   });
 
   it('GET /api/me with valid session returns account data', async () => {
@@ -608,6 +683,16 @@ describe('HTTP routes', () => {
     expect(
       must(entry, 'Expected tally entry for option 8').count,
     ).toBeGreaterThanOrEqual(1);
+  });
+
+  it('POST /api/example-vote rate limits write bursts per IP', async () => {
+    const headers = { 'CF-Connecting-IP': '203.0.113.207' };
+    let lastStatus = 0;
+    for (let i = 0; i < 41; i += 1) {
+      const resp = await post('/api/example-vote', {}, headers);
+      lastStatus = resp.status;
+    }
+    expect(lastStatus).toBe(429);
   });
 
   // ---- Cookie Secure attribute regression tests (issue #83) ----


### PR DESCRIPTION
## Summary
- add strict request body parsing and wallet/signature validation on auth/public-write routes
- add per-IP rate limiting for auth challenge/verify and example-vote writes
- add opportunistic cleanup for expired auth challenges and D1 index migration on expires_at
- replace unsafe leaderboard row double-cast with runtime parsing

## Testing
- npm run typecheck:worker
- npm run test:worker -- test/worker/http-routes.test.ts
- npm run lint -- src/worker/httpHandler.ts test/worker/http-routes.test.ts d1-migrations/0007_add_auth_challenge_expiry_index.sql

Fixes #205