### PR TITLE
[codex] Speed up CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
 
 jobs:
-  check:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -13,20 +13,74 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
+          cache: npm
+          cache-dependency-path: package-lock.json
 
       - run: npm ci
 
       - name: Lint
         run: npm run lint
 
+  typecheck-node:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - run: npm ci
+
       - name: Type check (Node)
         run: npm run typecheck
+
+  typecheck-worker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - run: npm ci
 
       - name: Type check (Worker)
         run: npm run typecheck:worker
 
+  domain-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - run: npm ci
+
       - name: Tests
         run: npm test -- --coverage
+
+  worker-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - run: npm ci
 
       - name: Worker tests
         run: npm run test:worker
@@ -34,7 +88,12 @@ jobs:
   staging-smoke:
     name: Staging deploy + smoke
     if: github.event.pull_request.head.repo.full_name == github.repository
-    needs: check
+    needs:
+      - lint
+      - typecheck-node
+      - typecheck-worker
+      - domain-tests
+      - worker-tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
     concurrency:
@@ -46,6 +105,8 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
+          cache: npm
+          cache-dependency-path: package-lock.json
 
       - run: npm ci
 

--- a/test/worker/game-room.test.ts
+++ b/test/worker/game-room.test.ts
@@ -54,6 +54,29 @@ function waitForMessage(
   });
 }
 
+/** Wait for a message that satisfies a predicate. */
+function waitForMessageWhere(
+  ws: WebSocket,
+  predicate: (msg: Record<string, unknown>) => boolean,
+  timeoutMs = 3000,
+): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const handler = (evt: MessageEvent) => {
+      const msg = JSON.parse(evt.data as string);
+      if (predicate(msg)) {
+        clearTimeout(timer);
+        ws.removeEventListener('message', handler);
+        resolve(msg);
+      }
+    };
+    const timer = setTimeout(() => {
+      ws.removeEventListener('message', handler);
+      reject(new Error('Timed out waiting for matching message'));
+    }, timeoutMs);
+    ws.addEventListener('message', handler);
+  });
+}
+
 /** Open a WebSocket for a wallet index, returning the client socket. */
 async function connectWs(
   walletIndex: number,
@@ -97,6 +120,29 @@ async function reconnectPlayer(
   walletIndex: number,
 ): Promise<{ ws: WebSocket; accountId: string }> {
   return connectWs(walletIndex);
+}
+
+/** Join queue and start immediately via unanimous start-now votes. */
+async function joinPlayersAndStartNow(
+  players: Array<{ ws: WebSocket }>,
+): Promise<void> {
+  const formingPromises = players.map((player) =>
+    waitForMessageWhere(
+      player.ws,
+      (msg) => msg.type === 'queue_state' && msg.status === 'forming',
+      3000,
+    ),
+  );
+
+  for (const player of players) {
+    player.ws.send(JSON.stringify({ type: 'join_queue' }));
+  }
+
+  await Promise.all(formingPromises);
+
+  for (const player of players) {
+    player.ws.send(JSON.stringify({ type: 'set_start_now', value: true }));
+  }
 }
 
 /** Connect N players, join queue, and await match_started for all. */
@@ -295,9 +341,7 @@ describe('GameRoom Durable Object', () => {
       MATCH_START_TIMEOUT_MS,
     );
 
-    p1.ws.send(JSON.stringify({ type: 'join_queue' }));
-    p2.ws.send(JSON.stringify({ type: 'join_queue' }));
-    p3.ws.send(JSON.stringify({ type: 'join_queue' }));
+    await joinPlayersAndStartNow([p1, p2, p3]);
 
     // Listen for game_started before awaiting match_started to avoid missing
     // back-to-back messages from the server.
@@ -375,9 +419,7 @@ describe('GameRoom Durable Object', () => {
       GAME_START_TIMEOUT_MS,
     );
 
-    p1.ws.send(JSON.stringify({ type: 'join_queue' }));
-    p2.ws.send(JSON.stringify({ type: 'join_queue' }));
-    p3.ws.send(JSON.stringify({ type: 'join_queue' }));
+    await joinPlayersAndStartNow([p1, p2, p3]);
 
     await Promise.all([p1Started, p2Started, p3Started]);
     await p1Round;
@@ -455,9 +497,7 @@ describe('GameRoom Durable Object', () => {
       GAME_START_TIMEOUT_MS,
     );
 
-    p1.ws.send(JSON.stringify({ type: 'join_queue' }));
-    p2.ws.send(JSON.stringify({ type: 'join_queue' }));
-    p3.ws.send(JSON.stringify({ type: 'join_queue' }));
+    await joinPlayersAndStartNow([p1, p2, p3]);
 
     await Promise.all([p1Started, p2Started, p3Started]);
     await Promise.all([p1Round, p2Round, p3Round]);
@@ -554,9 +594,7 @@ describe('GameRoom Durable Object', () => {
       GAME_START_TIMEOUT_MS,
     );
 
-    p1.ws.send(JSON.stringify({ type: 'join_queue' }));
-    p2.ws.send(JSON.stringify({ type: 'join_queue' }));
-    p3.ws.send(JSON.stringify({ type: 'join_queue' }));
+    await joinPlayersAndStartNow([p1, p2, p3]);
 
     await Promise.all([p1Started, p2Started, p3Started]);
     await Promise.all([p1Round, p2Round, p3Round]);
@@ -645,9 +683,7 @@ describe('GameRoom Durable Object', () => {
       GAME_START_TIMEOUT_MS,
     );
 
-    p1.ws.send(JSON.stringify({ type: 'join_queue' }));
-    p2.ws.send(JSON.stringify({ type: 'join_queue' }));
-    p3.ws.send(JSON.stringify({ type: 'join_queue' }));
+    await joinPlayersAndStartNow([p1, p2, p3]);
 
     await Promise.all([p1Started, p2Started, p3Started]);
     await Promise.all([p1Round, p2Round, p3Round]);
@@ -753,9 +789,7 @@ describe('GameRoom Durable Object', () => {
       GAME_START_TIMEOUT_MS,
     );
 
-    p1.ws.send(JSON.stringify({ type: 'join_queue' }));
-    p2.ws.send(JSON.stringify({ type: 'join_queue' }));
-    p3.ws.send(JSON.stringify({ type: 'join_queue' }));
+    await joinPlayersAndStartNow([p1, p2, p3]);
 
     await Promise.all([p1Started, p2Started, p3Started]);
     await Promise.all([p1Game1, p2Game1, p3Game1]);


### PR DESCRIPTION
## What changed

This PR cuts PR wall-clock time without dropping meaningful coverage.

- rewires the slow Worker integration scenarios in `test/worker/game-room.test.ts` to use the existing unanimous `set_start_now` path instead of repeatedly waiting for the 30s fill timer
- keeps the explicit fill-timer coverage in the dedicated match-formation test, so timer expiry is still exercised end to end
- splits CI into parallel `lint`, `typecheck-node`, `typecheck-worker`, `domain-tests`, and `worker-tests` jobs
- enables npm cache in each Actions job to reduce repeated install overhead

## Why

The main runtime cost was repeated real-time waiting in the Worker websocket suite, especially `test/worker/game-room.test.ts`. Several reconnect/result-path tests were each paying the same fill-timer wait even though they were not specifically validating fill-timer expiry.

The previous CI workflow also ran all checks serially in one job, so wall-clock time was the sum of lint, both typechecks, domain tests, and worker tests.

## Impact

- preserves the timer-expiry behavior coverage where it matters
- removes redundant waiting from the reconnect/result-path integration tests
- makes PR CI duration closer to the slowest lane instead of the sum of all lanes

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run typecheck:worker`
- `npm test -- --coverage`
- `npm run test:worker`

Local timing after the change:

- `test/worker/game-room.test.ts`: about 44.5s end to end in isolation
- `npm run test:worker`: about 44.9s end to end locally
