### PR TITLE
Harden WebSocket liveness and error handling

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -857,6 +857,28 @@ function notify(msg, type = '') {
   setTimeout(() => el.remove(), 4000);
 }
 
+const GLOBAL_ERROR_NOTIFY_COOLDOWN_MS = 8000;
+let lastGlobalErrorNoticeAt = 0;
+function notifyUnexpectedClientError() {
+  const now = Date.now();
+  if (now - lastGlobalErrorNoticeAt < GLOBAL_ERROR_NOTIFY_COOLDOWN_MS) return;
+  lastGlobalErrorNoticeAt = now;
+  notify(
+    'Unexpected client error. Reconnect in progress; refresh if it persists.',
+    'error',
+  );
+}
+
+window.addEventListener('error', (event) => {
+  console.error('Client runtime error', event.error || event.message);
+  notifyUnexpectedClientError();
+});
+
+window.addEventListener('unhandledrejection', (event) => {
+  console.error('Unhandled promise rejection', event.reason);
+  notifyUnexpectedClientError();
+});
+
 // ── Header profile ──────────────────────────────────────────────
 function updateHeaderProfile() {
   if (S.accountId) {
@@ -1262,6 +1284,7 @@ function onAuthComplete() {
 $('#logout-btn').addEventListener('click', async () => {
   intentionalClose = true;
   wsRetryCount = 0;
+  stopWebSocketHeartbeat();
   if (wsRetryTimer !== null) { clearTimeout(wsRetryTimer); wsRetryTimer = null; }
   if (S.ws) { S.ws.close(); S.ws = null; }
   try {
@@ -1336,9 +1359,57 @@ async function checkSession() {
 const WS_MAX_RETRIES = 10;
 const WS_BASE_DELAY = 1000;
 const WS_MAX_DELAY = 30000;
+const WS_HEARTBEAT_INTERVAL_MS = 10000;
+const WS_HEARTBEAT_TIMEOUT_MS = 12000;
 let wsRetryCount = 0;
 let intentionalClose = false;
 let wsRetryTimer = null;
+let wsHeartbeatTimer = null;
+let wsPongTimeoutTimer = null;
+let wsHeartbeatSocket = null;
+let wsAwaitingPong = false;
+
+function stopWebSocketHeartbeat(targetSocket = null) {
+  if (targetSocket && wsHeartbeatSocket !== targetSocket) return;
+  if (wsHeartbeatTimer !== null) {
+    clearInterval(wsHeartbeatTimer);
+    wsHeartbeatTimer = null;
+  }
+  if (wsPongTimeoutTimer !== null) {
+    clearTimeout(wsPongTimeoutTimer);
+    wsPongTimeoutTimer = null;
+  }
+  wsAwaitingPong = false;
+  wsHeartbeatSocket = null;
+}
+
+function acknowledgeWebSocketLiveness() {
+  wsAwaitingPong = false;
+  if (wsPongTimeoutTimer !== null) {
+    clearTimeout(wsPongTimeoutTimer);
+    wsPongTimeoutTimer = null;
+  }
+}
+
+function startWebSocketHeartbeat(targetSocket) {
+  stopWebSocketHeartbeat();
+  wsHeartbeatSocket = targetSocket;
+  wsHeartbeatTimer = setInterval(() => {
+    if (targetSocket !== S.ws || !isWebSocketOpen()) return;
+    if (wsAwaitingPong) {
+      notify('Connection heartbeat timed out. Reconnecting...', 'warn');
+      try { targetSocket.close(4000, 'Heartbeat timeout'); } catch (_) {}
+      return;
+    }
+    wsAwaitingPong = true;
+    wsSend({ type: 'ping', sentAt: Date.now() });
+    wsPongTimeoutTimer = setTimeout(() => {
+      if (targetSocket !== S.ws || !wsAwaitingPong) return;
+      notify('Connection heartbeat timed out. Reconnecting...', 'warn');
+      try { targetSocket.close(4000, 'Heartbeat timeout'); } catch (_) {}
+    }, WS_HEARTBEAT_TIMEOUT_MS);
+  }, WS_HEARTBEAT_INTERVAL_MS);
+}
 
 function isWebSocketOpen() {
   return !!S.ws && S.ws.readyState === WebSocket.OPEN;
@@ -1394,6 +1465,7 @@ function connectWebSocket() {
   if (!S.accountId) return;
   wsRetryTimer = null;
   S.wsConnected = false;
+  stopWebSocketHeartbeat();
   const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
   S.ws = new WebSocket(`${proto}//${location.host}/ws`);
   const thisWs = S.ws;
@@ -1402,15 +1474,18 @@ function connectWebSocket() {
     wsRetryCount = 0;
     wsRetryTimer = null;
     S.wsConnected = true;
+    startWebSocketHeartbeat(thisWs);
     flushPendingQueueAction();
     renderQueue();
   };
   S.ws.onerror = () => {
     if (thisWs !== S.ws) return;
+    stopWebSocketHeartbeat(thisWs);
     S.wsConnected = false;
     renderQueue();
   };
   S.ws.onclose = () => {
+    stopWebSocketHeartbeat(thisWs);
     if (thisWs === S.ws) {
       S.wsConnected = false;
       renderQueue();
@@ -1426,7 +1501,18 @@ function connectWebSocket() {
     wsRetryTimer = setTimeout(connectWebSocket, delay);
   };
   S.ws.onmessage = (evt) => {
-    const msg = JSON.parse(evt.data);
+    let msg;
+    try {
+      msg = JSON.parse(evt.data);
+    } catch (error) {
+      console.error('WS: invalid message payload', error);
+      notify('Received invalid server payload. Reconnecting...', 'warn');
+      if (thisWs === S.ws) {
+        try { thisWs.close(4002, 'Invalid payload'); } catch (_) {}
+      }
+      return;
+    }
+    acknowledgeWebSocketLiveness();
     handleMessage(msg);
   };
 }
@@ -1453,6 +1539,7 @@ function handleMessage(msg) {
     case 'player_reconnected': onPlayerReconnected(msg); break;
     case 'player_forfeited': onPlayerForfeited(msg); break;
     case 'prompt_rating_tally': onPromptRatingTally(msg); break;
+    case 'pong': break;
     case 'error': notify(msg.message, 'error'); break;
     default: break;
   }

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -10,7 +10,8 @@ export type ClientMessage =
   | { type: 'commit'; hash: string }
   | { type: 'reveal'; optionIndex: number; salt: string }
   | { type: 'reveal'; answerText: string; salt: string }
-  | { type: 'prompt_rating'; rating: 'like' | 'dislike' };
+  | { type: 'prompt_rating'; rating: 'like' | 'dislike' }
+  | { type: 'ping'; sentAt?: number };
 
 // ── Server → Client ──────────────────────────────────────────────
 
@@ -124,6 +125,12 @@ export interface ErrorMessage {
   message: string;
 }
 
+export interface PongMessage {
+  type: 'pong';
+  sentAt?: number;
+  serverTime: number;
+}
+
 export type ServerMessage =
   | QueueStateMessage
   | MatchStartedMessage
@@ -137,4 +144,5 @@ export type ServerMessage =
   | PlayerForfeitedMessage
   | PlayerReconnectedMessage
   | PromptRatingTallyMessage
-  | ErrorMessage;
+  | ErrorMessage
+  | PongMessage;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -24,6 +24,7 @@ import type {
   SchellingPrompt,
 } from './types/domain';
 import type {
+  ClientMessage,
   GameResultMessage,
   QueueStateMessage,
   ServerMessage,
@@ -52,6 +53,8 @@ interface ConnectionState {
   displayName: string;
   startNow: boolean;
   previousOpponents: Set<string>;
+  lastActivityAt: number;
+  livenessTimer: ReturnType<typeof setInterval> | null;
 }
 
 interface WorkerPlayerState extends PersistedPlayerState {
@@ -123,6 +126,8 @@ const AI_BOT_COMMIT_BUFFER_MS = 1_500;
 const DEFAULT_OPEN_TEXT_NORMALIZER_MODEL =
   '@cf/meta/llama-3.3-70b-instruct-fp8-fast';
 const DEFAULT_OPEN_TEXT_NORMALIZER_TIMEOUT_MS = 3_000;
+const WS_LIVENESS_CHECK_INTERVAL_MS = 10_000;
+const WS_IDLE_TIMEOUT_MS = 35_000;
 
 function cloneJson<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
@@ -243,7 +248,9 @@ export class GameRoom {
           }
           playerState.disconnectedAt = null;
           playerState.ws = ws;
+          this._clearConnectionLivenessMonitor(accountId);
           existingConn.ws = ws;
+          existingConn.lastActivityAt = Date.now();
           this._checkpointPlayerAction(existingMatchId, accountId, {
             disconnectedAt: null,
           });
@@ -274,6 +281,8 @@ export class GameRoom {
             displayName,
             startNow: false,
             previousOpponents: new Set(),
+            lastActivityAt: Date.now(),
+            livenessTimer: null,
           });
           if (playerState.graceTimer) {
             clearTimeout(playerState.graceTimer);
@@ -312,6 +321,7 @@ export class GameRoom {
 
     // Close previous connection if any (not a match reconnect)
     if (existingConn) {
+      this._clearConnectionLivenessMonitor(accountId);
       try {
         existingConn.ws.close(1000, 'Replaced by new connection');
       } catch {}
@@ -328,6 +338,8 @@ export class GameRoom {
       previousOpponents: existingConn
         ? existingConn.previousOpponents
         : new Set(),
+      lastActivityAt: Date.now(),
+      livenessTimer: null,
     });
 
     this._setupWsListeners(ws, accountId);
@@ -336,20 +348,91 @@ export class GameRoom {
     this._sendQueueState(accountId);
   }
 
+  _noteConnectionActivity(accountId: string, ws: WebSocket): void {
+    const conn = this.connections.get(accountId);
+    if (!conn || conn.ws !== ws) return;
+    conn.lastActivityAt = Date.now();
+  }
+
+  _clearConnectionLivenessMonitor(accountId: string): void {
+    const conn = this.connections.get(accountId);
+    if (!conn?.livenessTimer) return;
+    clearInterval(conn.livenessTimer);
+    conn.livenessTimer = null;
+  }
+
+  _startConnectionLivenessMonitor(accountId: string, ws: WebSocket): void {
+    this._clearConnectionLivenessMonitor(accountId);
+    const conn = this.connections.get(accountId);
+    if (!conn || conn.ws !== ws) return;
+    conn.lastActivityAt = Date.now();
+    conn.livenessTimer = setInterval(() => {
+      const current = this.connections.get(accountId);
+      if (!current || current.ws !== ws) {
+        this._clearConnectionLivenessMonitor(accountId);
+        return;
+      }
+      if (Date.now() - current.lastActivityAt < WS_IDLE_TIMEOUT_MS) return;
+
+      this._clearConnectionLivenessMonitor(accountId);
+      try {
+        ws.close(4000, 'Heartbeat timeout');
+      } catch {}
+    }, WS_LIVENESS_CHECK_INTERVAL_MS);
+  }
+
   _setupWsListeners(ws: WebSocket, accountId: string): void {
+    this._startConnectionLivenessMonitor(accountId, ws);
+    const isCurrentConnection = (): boolean =>
+      this.connections.get(accountId)?.ws === ws;
+
     ws.addEventListener('message', (evt: MessageEvent) => {
+      if (!isCurrentConnection()) return;
+      this._noteConnectionActivity(accountId, ws);
       this._waitUntil(
         (async () => {
-          try {
-            const msg = JSON.parse(evt.data as string) as {
-              type: string;
-              [key: string]: unknown;
-            };
-            await this._handleMessage(accountId, msg);
-          } catch (e) {
+          const raw = evt.data;
+          if (typeof raw !== 'string') {
             this._sendTo(accountId, {
               type: 'error',
-              message: (e as Error).message || 'Internal error',
+              message: 'Invalid message payload.',
+            });
+            return;
+          }
+
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(raw);
+          } catch {
+            this._sendTo(accountId, {
+              type: 'error',
+              message: 'Invalid message payload.',
+            });
+            return;
+          }
+
+          if (
+            !parsed ||
+            typeof parsed !== 'object' ||
+            typeof (parsed as { type?: unknown }).type !== 'string'
+          ) {
+            this._sendTo(accountId, {
+              type: 'error',
+              message: 'Invalid message payload.',
+            });
+            return;
+          }
+
+          try {
+            await this._handleMessage(accountId, parsed as ClientMessage);
+          } catch (error) {
+            console.error('WebSocket message handling failed', {
+              accountId,
+              error,
+            });
+            this._sendTo(accountId, {
+              type: 'error',
+              message: 'Unable to process message.',
             });
           }
         })(),
@@ -358,10 +441,14 @@ export class GameRoom {
     });
 
     ws.addEventListener('close', () => {
+      if (!isCurrentConnection()) return;
+      this._clearConnectionLivenessMonitor(accountId);
       this._handleDisconnect(accountId);
     });
 
     ws.addEventListener('error', () => {
+      if (!isCurrentConnection()) return;
+      this._clearConnectionLivenessMonitor(accountId);
       this._handleDisconnect(accountId);
     });
   }
@@ -389,6 +476,13 @@ export class GameRoom {
         return this._handleReveal(accountId, msg);
       case 'prompt_rating':
         return this._handlePromptRating(accountId, msg);
+      case 'ping':
+        this._sendTo(accountId, {
+          type: 'pong',
+          serverTime: Date.now(),
+          ...(typeof msg.sentAt === 'number' ? { sentAt: msg.sentAt } : {}),
+        });
+        return;
       default:
         this._sendTo(accountId, {
           type: 'error',
@@ -2162,6 +2256,7 @@ export class GameRoom {
   // -------------------------------------------------------------------------
 
   _handleDisconnect(accountId: string): void {
+    this._clearConnectionLivenessMonitor(accountId);
     const matchId = this.playerMatchIndex.get(accountId);
 
     if (!matchId) {

--- a/test/worker/game-room-async.test.ts
+++ b/test/worker/game-room-async.test.ts
@@ -48,15 +48,33 @@ function createRoom(envOverrides: Partial<Env> = {}) {
   return { room, waitUntil };
 }
 
-function createConnectionState(displayName: string) {
+function createConnectionState(displayName: string, wsOverride?: WebSocket) {
   return {
-    ws: {
-      send: vi.fn(),
-    } as unknown as WebSocket,
+    ws:
+      wsOverride ??
+      ({
+        send: vi.fn(),
+      } as unknown as WebSocket),
     displayName,
     startNow: false,
     previousOpponents: new Set<string>(),
+    lastActivityAt: Date.now(),
+    livenessTimer: null,
   };
+}
+
+function createSocketWithListeners() {
+  const listeners = new Map<string, (evt?: MessageEvent) => void>();
+  const ws = {
+    send: vi.fn(),
+    close: vi.fn(),
+    addEventListener: vi.fn(
+      (type: string, handler: (evt?: MessageEvent) => void) => {
+        listeners.set(type, handler);
+      },
+    ),
+  } as unknown as WebSocket;
+  return { ws, listeners };
 }
 
 function createMatch() {
@@ -91,15 +109,8 @@ describe('GameRoom async task tracking', () => {
     const handleMessage = vi
       .spyOn(room, '_handleMessage')
       .mockResolvedValue(undefined);
-
-    const listeners = new Map<string, (evt: MessageEvent) => void>();
-    const ws = {
-      addEventListener: vi.fn(
-        (type: string, handler: (evt: MessageEvent) => void) => {
-          listeners.set(type, handler);
-        },
-      ),
-    } as unknown as WebSocket;
+    const { ws, listeners } = createSocketWithListeners();
+    room.connections.set('acct-1', createConnectionState('Alice', ws));
 
     room._setupWsListeners(ws, 'acct-1');
 
@@ -118,6 +129,105 @@ describe('GameRoom async task tracking', () => {
     expect(handleMessage).toHaveBeenCalledWith('acct-1', {
       type: 'join_queue',
     });
+  });
+
+  it('rejects malformed websocket payloads without dispatching handlers', async () => {
+    const { room, waitUntil } = createRoom();
+    const handleMessage = vi
+      .spyOn(room, '_handleMessage')
+      .mockResolvedValue(undefined);
+    const sendTo = vi.spyOn(room, '_sendTo').mockImplementation(() => {});
+    const { ws, listeners } = createSocketWithListeners();
+    room.connections.set('acct-1', createConnectionState('Alice', ws));
+
+    room._setupWsListeners(ws, 'acct-1');
+
+    const onMessage = must(
+      listeners.get('message'),
+      'Expected message listener',
+    );
+    onMessage({
+      data: '{"type":"join_queue"',
+    } as MessageEvent);
+
+    expect(waitUntil).toHaveBeenCalledTimes(1);
+    await must(waitUntil.mock.calls[0], 'Expected waitUntil call')[0];
+    expect(handleMessage).not.toHaveBeenCalled();
+    expect(sendTo).toHaveBeenCalledWith('acct-1', {
+      type: 'error',
+      message: 'Invalid message payload.',
+    });
+  });
+
+  it('sanitizes websocket handler exceptions before responding', async () => {
+    const { room, waitUntil } = createRoom();
+    vi.spyOn(room, '_handleMessage').mockRejectedValue(
+      new Error('internal stack detail'),
+    );
+    const sendTo = vi.spyOn(room, '_sendTo').mockImplementation(() => {});
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const { ws, listeners } = createSocketWithListeners();
+    room.connections.set('acct-1', createConnectionState('Alice', ws));
+
+    try {
+      room._setupWsListeners(ws, 'acct-1');
+
+      const onMessage = must(
+        listeners.get('message'),
+        'Expected message listener',
+      );
+      onMessage({
+        data: JSON.stringify({ type: 'join_queue' }),
+      } as MessageEvent);
+
+      expect(waitUntil).toHaveBeenCalledTimes(1);
+      await must(waitUntil.mock.calls[0], 'Expected waitUntil call')[0];
+      expect(sendTo).toHaveBeenCalledWith('acct-1', {
+        type: 'error',
+        message: 'Unable to process message.',
+      });
+      expect(sendTo).not.toHaveBeenCalledWith(
+        'acct-1',
+        expect.objectContaining({ message: 'internal stack detail' }),
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it('responds to ping with pong metadata', async () => {
+    const { room } = createRoom();
+    const sendTo = vi.spyOn(room, '_sendTo').mockImplementation(() => {});
+
+    await room._handleMessage('acct-1', { type: 'ping', sentAt: 1234 });
+
+    expect(sendTo).toHaveBeenCalledWith(
+      'acct-1',
+      expect.objectContaining({
+        type: 'pong',
+        sentAt: 1234,
+        serverTime: expect.any(Number),
+      }),
+    );
+  });
+
+  it('closes idle websocket connections after heartbeat timeout', () => {
+    vi.useFakeTimers();
+    try {
+      const { room } = createRoom();
+      const { ws } = createSocketWithListeners();
+      room.connections.set('acct-1', createConnectionState('Alice', ws));
+
+      room._setupWsListeners(ws, 'acct-1');
+      vi.advanceTimersByTime(40_000);
+
+      expect(ws.close).toHaveBeenCalledWith(4000, 'Heartbeat timeout');
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
   });
 
   it('tracks reveal-triggered game finalization with state.waitUntil', async () => {


### PR DESCRIPTION
## Summary
- add client-side WebSocket hardening in `public/app.html`:
  - guard inbound `JSON.parse` with reconnect-on-invalid-payload behavior
  - add heartbeat ping/pong timers with timeout-driven reconnect
  - add top-level `error` and `unhandledrejection` handlers with throttled user notification
- harden Durable Object WebSocket handling in `src/worker.ts`:
  - validate message payload shape before dispatch
  - sanitize client-facing errors while logging server-side failures
  - add per-connection liveness tracking and idle timeout close logic
  - ignore stale socket events after reconnect/replacement
  - support `ping` client messages and `pong` server messages
- extend protocol and tests:
  - add `ping`/`pong` message types in `src/types/messages.ts`
  - add async worker tests for malformed payloads, sanitized exceptions, ping/pong, and heartbeat timeout behavior

Closes #202

## Validation
- `npm run test:worker -- test/worker/game-room-async.test.ts`
- `npm run test:worker -- test/worker/game-room.test.ts`
- `npm run typecheck:worker`
- `npx biome check public/app.html src/types/messages.ts src/worker.ts test/worker/game-room-async.test.ts`