### PR TITLE
[codex] Move lifecycle soak out of PR CI

### DIFF
--- a/.github/workflows/extended-worker-tests.yml
+++ b/.github/workflows/extended-worker-tests.yml
@@ -1,0 +1,25 @@
+name: Extended Worker Tests
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 5 * * *'
+  workflow_dispatch:
+
+jobs:
+  full-lifecycle-soak:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - run: npm ci
+
+      - name: Full lifecycle worker soak
+        run: npm run test:worker:extended

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "npm run db:migrate:local && npx wrangler dev",
     "test": "vitest run",
     "test:worker": "vitest run --config vitest.config.worker.ts",
+    "test:worker:extended": "RUN_EXTENDED_WORKER_TESTS=1 vitest run --config vitest.config.worker.ts test/worker/game-room.test.ts -t \"runs a full 10-game lifecycle and emits match_over\"",
     "smoke:staging": "node scripts/smoke-staging.mjs",
     "lint": "biome check .",
     "typecheck": "tsc --noEmit",

--- a/test/worker/game-room.test.ts
+++ b/test/worker/game-room.test.ts
@@ -13,10 +13,14 @@ import {
   seedAccount,
 } from './helpers';
 
+declare const __RUN_EXTENDED_WORKER_TESTS__: boolean;
+
 const BASE = 'https://test.local';
 const MATCH_START_TIMEOUT_MS = 40_000;
 const GAME_START_TIMEOUT_MS = 45_000;
 const MATCH_OVER_TIMEOUT_MS = 20_000;
+const extendedWorkerTestsEnabled = __RUN_EXTENDED_WORKER_TESTS__;
+const extendedIt = extendedWorkerTestsEnabled ? it : it.skip;
 
 function makeSalt(gameNum: number, playerIdx: number): string {
   const nibbleA = (gameNum % 16).toString(16);
@@ -1093,84 +1097,90 @@ describe('GameRoom Durable Object', () => {
     p3.ws.close();
   });
 
-  it('runs a full 10-game lifecycle and emits match_over', {
-    timeout: 180_000,
-  }, async () => {
-    const p1 = await connectPlayer(25, 'FullP1', 100_000);
-    const p2 = await connectPlayer(26, 'FullP2', 100_000);
-    const p3 = await connectPlayer(27, 'FullP3', 100_000);
-    const players = [p1, p2, p3];
+  extendedIt(
+    'runs a full 10-game lifecycle and emits match_over',
+    {
+      timeout: 180_000,
+    },
+    async () => {
+      const p1 = await connectPlayer(25, 'FullP1', 100_000);
+      const p2 = await connectPlayer(26, 'FullP2', 100_000);
+      const p3 = await connectPlayer(27, 'FullP3', 100_000);
+      const players = [p1, p2, p3];
 
-    const matchStartedPromises = players.map((p) =>
-      waitForMessage(p.ws, 'match_started', MATCH_START_TIMEOUT_MS),
-    );
-    let gameStartedPromises = players.map((p) =>
-      waitForMessage(p.ws, 'game_started', GAME_START_TIMEOUT_MS),
-    );
-
-    for (const player of players) {
-      player.ws.send(JSON.stringify({ type: 'join_queue' }));
-    }
-
-    const started = await Promise.all(matchStartedPromises);
-    for (const message of started) {
-      expect(message.gameCount).toBe(10);
-      expect(message.matchId).toBe(started[0].matchId);
-    }
-
-    for (let gameNum = 1; gameNum <= 10; gameNum++) {
-      const gameStarted = await Promise.all(gameStartedPromises);
-      const prompt = gameStarted[0]?.prompt as SchellingPrompt;
-      for (const message of gameStarted) {
-        expect(message.game).toBe(gameNum);
-        expect(message.phase).toBe('commit');
-        expect(message.prompt).toEqual(prompt);
-      }
-
-      const phaseChange = waitForMessage(players[0].ws, 'phase_change', 5_000);
-      for (let i = 0; i < players.length; i++) {
-        const salt = makeSalt(gameNum, i + 1);
-        const action = buildPromptAction(prompt, salt, 0);
-        players[i].ws.send(
-          JSON.stringify({ type: 'commit', hash: action.hash }),
-        );
-      }
-      const phase = await phaseChange;
-      expect(phase.phase).toBe('reveal');
-
-      const gameResult = waitForMessage(
-        players[0].ws,
-        'game_result',
-        getGameResultTimeoutMs(prompt),
+      const matchStartedPromises = players.map((p) =>
+        waitForMessage(p.ws, 'match_started', MATCH_START_TIMEOUT_MS),
       );
-      for (let i = 0; i < players.length; i++) {
-        const salt = makeSalt(gameNum, i + 1);
-        const action = buildPromptAction(prompt, salt, 0);
-        players[i].ws.send(JSON.stringify(action.reveal));
+      let gameStartedPromises = players.map((p) =>
+        waitForMessage(p.ws, 'game_started', GAME_START_TIMEOUT_MS),
+      );
+
+      await joinPlayersAndStartNow(players);
+
+      const started = await Promise.all(matchStartedPromises);
+      for (const message of started) {
+        expect(message.gameCount).toBe(10);
+        expect(message.matchId).toBe(started[0].matchId);
       }
 
-      const result = await gameResult;
-      expect(result.type).toBe('game_result');
-      expect(result.result.gameNum).toBe(gameNum);
+      for (let gameNum = 1; gameNum <= 10; gameNum++) {
+        const gameStarted = await Promise.all(gameStartedPromises);
+        const prompt = gameStarted[0]?.prompt as SchellingPrompt;
+        for (const message of gameStarted) {
+          expect(message.game).toBe(gameNum);
+          expect(message.phase).toBe('commit');
+          expect(message.prompt).toEqual(prompt);
+        }
 
-      if (gameNum < 10) {
-        gameStartedPromises = players.map((p) =>
-          waitForMessage(p.ws, 'game_started', 15_000),
+        const phaseChange = waitForMessage(
+          players[0].ws,
+          'phase_change',
+          5_000,
         );
+        for (let i = 0; i < players.length; i++) {
+          const salt = makeSalt(gameNum, i + 1);
+          const action = buildPromptAction(prompt, salt, 0);
+          players[i].ws.send(
+            JSON.stringify({ type: 'commit', hash: action.hash }),
+          );
+        }
+        const phase = await phaseChange;
+        expect(phase.phase).toBe('reveal');
+
+        const gameResult = waitForMessage(
+          players[0].ws,
+          'game_result',
+          getGameResultTimeoutMs(prompt),
+        );
+        for (let i = 0; i < players.length; i++) {
+          const salt = makeSalt(gameNum, i + 1);
+          const action = buildPromptAction(prompt, salt, 0);
+          players[i].ws.send(JSON.stringify(action.reveal));
+        }
+
+        const result = await gameResult;
+        expect(result.type).toBe('game_result');
+        expect(result.result.gameNum).toBe(gameNum);
+
+        if (gameNum < 10) {
+          gameStartedPromises = players.map((p) =>
+            waitForMessage(p.ws, 'game_started', 15_000),
+          );
+        }
       }
-    }
 
-    const matchOver = await waitForMessage(
-      players[0].ws,
-      'match_over',
-      MATCH_OVER_TIMEOUT_MS,
-    );
-    expect(matchOver.type).toBe('match_over');
-    expect(Array.isArray(matchOver.summary.players)).toBe(true);
-    expect(matchOver.summary.players).toHaveLength(3);
+      const matchOver = await waitForMessage(
+        players[0].ws,
+        'match_over',
+        MATCH_OVER_TIMEOUT_MS,
+      );
+      expect(matchOver.type).toBe('match_over');
+      expect(Array.isArray(matchOver.summary.players)).toBe(true);
+      expect(matchOver.summary.players).toHaveLength(3);
 
-    for (const player of players) {
-      player.ws.close();
-    }
-  });
+      for (const player of players) {
+        player.ws.close();
+      }
+    },
+  );
 });

--- a/vitest.config.worker.ts
+++ b/vitest.config.worker.ts
@@ -11,8 +11,13 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export default defineConfig(async () => {
   const migrationsPath = path.join(__dirname, 'd1-migrations');
   const migrations = await readD1Migrations(migrationsPath);
+  const runExtendedWorkerTests =
+    process.env.RUN_EXTENDED_WORKER_TESTS === '1';
 
   return {
+    define: {
+      __RUN_EXTENDED_WORKER_TESTS__: JSON.stringify(runExtendedWorkerTests),
+    },
     plugins: [
       cloudflareTest({
         // Keep worker tests hermetic and CI-friendly. Staging validation runs


### PR DESCRIPTION
## What changed

This PR removes the full 10-game websocket lifecycle soak from the default PR worker test lane and keeps it available as an explicit extended check.

- gates the `runs a full 10-game lifecycle and emits match_over` test behind a Vitest config define so it is skipped in the normal `test:worker` path
- adds `npm run test:worker:extended` to run only that soak test on demand
- adds a dedicated `Extended Worker Tests` workflow for `push` to `main`, nightly schedule, and manual dispatch
- updates the soak test to use the existing unanimous `joinPlayersAndStartNow()` helper so the extended run no longer pays the initial 30s fill timer

## Why

On latest `origin/main`, the single 10-game lifecycle test was consuming most of the worker-test lane by itself.

Measured locally before this change:
- `npm run test:worker`: about 2m26s wall time
- full lifecycle soak only: about 1m42s wall time

That made the soak a poor fit for PR CI, where the faster worker integration coverage already exercises:
- queue to match start
- multi-round progression
- reconnect during commit/results
- rating replay
- end-match and `match_over` behavior via the async worker tests

## Impact

- PR CI keeps meaningful worker integration coverage but drops the long soak from the critical path
- the soak coverage still exists and runs outside the fast PR path
- the explicit extended soak is also faster because it skips the initial 30s fill wait

Measured locally after this change:
- `npm run test:worker`: about 46s wall time
- `npm run test:worker:extended`: about 72s wall time

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run typecheck:worker`
- `npm test -- --coverage`
- `npm run test:worker`
- `npm run test:worker:extended`
