### PR TITLE
[codex] fix deploy badge rate-limit polling

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -4,4 +4,4 @@
   X-Frame-Options: DENY
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; connect-src 'self' wss: ws://localhost:* ws://127.0.0.1:* https://api.github.com; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; connect-src 'self' wss: ws://localhost:* ws://127.0.0.1:*; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; upgrade-insecure-requests

--- a/public/shared-deploy.js
+++ b/public/shared-deploy.js
@@ -1,38 +1,19 @@
-/* Deploy status indicator (shared across index.html and app.html) */
+/* Build badge (shared across index.html and app.html) */
 (function() {
   var el = document.getElementById('deploy-status');
   if (!el) return;
-  var labels = { success: 'deployed', in_progress: 'deploying new version', failure: 'deploy failed' };
-  var pending = false;
-  var timer = null;
 
-  function schedule() {
-    clearInterval(timer);
-    // 60s while deploying, 90s otherwise (stays under 60 req/hr GitHub limit)
-    timer = setInterval(check, pending ? 60000 : 90000);
-  }
+  var meta = el.previousElementSibling;
+  var metaText = meta && typeof meta.textContent === 'string' ? meta.textContent : '';
+  var isStamped =
+    metaText.indexOf('__BUILD_HASH__') === -1 &&
+    metaText.indexOf('__BUILD_DATE__') === -1;
+  var status = isStamped ? 'success' : 'in_progress';
+  var text = isStamped ? 'live build' : 'local dev';
+  var dot = document.createElement('span');
 
-  function check() {
-    fetch('https://api.github.com/repos/0xferit/schelling-game/actions/runs?per_page=1&branch=main')
-      .then(function(r) { return r.json(); })
-      .then(function(data) {
-        if (!data.workflow_runs || !data.workflow_runs.length) return;
-        var run = data.workflow_runs[0];
-        var status = run.status === 'completed' ? run.conclusion : 'in_progress';
-        var text = labels[status] || status;
-        var dot = document.createElement('span');
-        dot.className = 'dot ' + status;
-        el.textContent = '';
-        el.appendChild(dot);
-        el.appendChild(document.createTextNode(text));
-        if ((status === 'in_progress') !== pending) {
-          pending = status === 'in_progress';
-          schedule();
-        }
-      })
-      .catch(function() {});
-  }
-
-  check();
-  schedule();
+  dot.className = 'dot ' + status;
+  el.textContent = '';
+  el.appendChild(dot);
+  el.appendChild(document.createTextNode(text));
 })();

--- a/test/domain/csp-headers.test.ts
+++ b/test/domain/csp-headers.test.ts
@@ -15,7 +15,7 @@ describe('asset CSP', () => {
     expect(contentSecurityPolicy).toContain("connect-src 'self' wss:");
     expect(contentSecurityPolicy).toContain('ws://localhost:*');
     expect(contentSecurityPolicy).toContain('ws://127.0.0.1:*');
-    expect(contentSecurityPolicy).toContain('https://api.github.com');
+    expect(contentSecurityPolicy).not.toContain('https://api.github.com');
     expect(contentSecurityPolicy).not.toContain('wss://schelling.games');
   });
 });

--- a/test/domain/shared-deploy.test.ts
+++ b/test/domain/shared-deploy.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const sharedDeployScript = readFileSync(
+  new URL('../../public/shared-deploy.js', import.meta.url),
+  'utf8',
+);
+
+describe('shared deploy badge', () => {
+  it('does not poll the GitHub API from the browser', () => {
+    expect(sharedDeployScript).not.toContain('api.github.com');
+    expect(sharedDeployScript).not.toContain('actions/runs');
+  });
+
+  it('renders a local build badge from stamped metadata', () => {
+    expect(sharedDeployScript).toContain('live build');
+    expect(sharedDeployScript).toContain('local dev');
+  });
+});


### PR DESCRIPTION
## Summary

This PR removes the frontend's unauthenticated GitHub Actions polling from the shared deploy badge and replaces it with a local build-status badge derived from the stamped footer metadata.

## Root Cause

The browser was polling `https://api.github.com/repos/0xferit/schelling-game/actions/runs?per_page=1&branch=main` from every client. Those anonymous requests were hitting GitHub's REST API rate limit and surfacing `API rate limit exceeded` errors in the app.

## Changes

- replace the shared deploy badge script with a local badge that renders `live build` for stamped deploys and `local dev` for unstamped local runs
- remove `https://api.github.com` from the static asset CSP
- update the CSP test to assert GitHub API access is no longer allowed
- add a regression test to ensure the shared deploy script does not reintroduce GitHub polling

## Impact

Users no longer trigger GitHub API rate-limit errors just by loading the app, and the asset CSP now matches the frontend's actual network needs.

## Validation

- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run typecheck:worker`
- `npm run test:worker` was attempted twice locally but hung after `workerd` startup with no assertion failure output