### PR TITLE
Restore limited AI queue backfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Wrangler-managed bindings and default variables live in [wrangler.toml](wrangler
 | `GAME_ROOM` | Yes | `wrangler.toml` | Durable Object namespace for the singleton `GameRoom` lobby/match coordinator. |
 | `AI` | Optional | `wrangler.toml` | Workers AI binding used for open-text answer normalization. |
 | `ADMIN_KEY` | Optional | Worker secret/var | Protects admin-only HTTP routes such as leaderboard eligibility and CSV export. |
-| `AI_BOT_ENABLED` | Optional | `wrangler.toml` var | Legacy flag for AI queue backfill. Public mixed-mode matches now disable bot backfill even if this is enabled. |
+| `AI_BOT_ENABLED` | Optional | `wrangler.toml` var | Enables limited AI queue backfill for `1`- or `2`-human public queues. Bot-assisted matches stay off the record. |
 | `AI_BOT_MODELS` | Optional | `wrangler.toml` var | Comma-separated Workers AI model list for backfill bot selection. |
 | `AI_BOT_TIMEOUT_MS` | Optional | `wrangler.toml` var | Timeout budget for Workers AI bot decisions. |
 | `OPEN_TEXT_PROMPTS_ENABLED` | Required for public play | `wrangler.toml` var | Enables the canonical mixed prompt catalog. If disabled, public matches will not start. |

--- a/docs/adr/0011-restore-limited-ai-backfill.md
+++ b/docs/adr/0011-restore-limited-ai-backfill.md
@@ -1,0 +1,35 @@
+# ADR 0011: Restore limited AI backfill for ten-seed public mode
+
+Status: Accepted
+Date: 2026-03-30
+
+Supersession note: This ADR supersedes ADR [0010](0010-ten-seed-ai-normalized-public-mode.md)'s blanket prohibition on AI-assisted public matches. The rest of ADR `0010` remains canonical.
+
+## Context
+
+ADR `0010` correctly narrowed the public product to one fixed ten-prompt catalog with authoritative Workers AI normalization for `open_text` settlement. In the same change, public AI-assisted matches were disabled entirely.
+
+That removal regressed queue availability. A solo or duo human lobby can no longer promote itself to a playable public match, even though:
+
+- the runtime already supports synthetic players end to end
+- AI-assisted matches are already neutralized economically
+- the public UI already explains that bot-assisted runs are off the record
+
+The intended product behavior from ADR `0008` was narrower than a blanket ban: AI backfill should remain limited to raising `1`- or `2`-human public queues to the minimum playable size of `3`.
+
+## Decision
+
+The ten-seed public catalog keeps authoritative Workers AI normalization for `open_text` prompts, and also restores limited AI backfill:
+
+- automatic AI backfill is enabled only when `AI_BOT_ENABLED` is true
+- automatic AI backfill is limited to public queues with `1` or `2` humans
+- bots are used only to reach the minimum playable size of `3`
+- if additional humans arrive before launch, synthetic seats are removed and replaced by humans
+- AI-assisted matches remain off the record: balances, streaks, and leaderboard standing do not change
+
+## Consequences
+
+- low-concurrency public sessions regain a playable path instead of stalling below `3`
+- the fill-timer and unanimous `start now` flow remain intact because backfilled lobbies still form through the normal queue path
+- human-only crowds of `3+` players continue to launch without synthetic seats
+- the public rules and config docs must describe AI backfill as limited availability support, not a disabled legacy path

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,3 +22,4 @@ Format:
 | [0008](./0008-remove-public-odd-match-requirement.md) | Remove public odd-match requirement | Accepted | 2026-03-29 |
 | [0009](./0009-hybrid-prompt-public-mode.md) | Hybrid prompt public mode | Superseded | 2026-03-29 |
 | [0010](./0010-ten-seed-ai-normalized-public-mode.md) | Ten-seed AI-normalized public mode | Accepted | 2026-03-30 |
+| [0011](./0011-restore-limited-ai-backfill.md) | Restore limited AI backfill for ten-seed public mode | Accepted | 2026-03-30 |

--- a/docs/game-design.md
+++ b/docs/game-design.md
@@ -37,7 +37,8 @@ The intended skill is not specialist knowledge. It is identifying focal points t
   - `5` `open_text` prompts: number `1..10`, playing card, fair split keep amount, city, word
 - Every public human match uses all `10` prompts exactly once in shuffled order.
 - `open_text` prompts are a hard prerequisite for public play. If `OPEN_TEXT_PROMPTS_ENABLED` is off, public matches do not start and the reserved cohort is restored to the waiting queue.
-- AI-assisted public matches and select-only public matches are unavailable for this catalog.
+- Limited AI backfill may raise a `1`- or `2`-human public queue to the minimum match size of `3`.
+- AI-assisted public matches remain off the record for this catalog: balances, streaks, and leaderboard standing do not change.
 - Phase timings are fixed (source of truth: `src/domain/constants.ts`):
   - commit: `60` seconds
   - reveal: `15` seconds

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -707,6 +707,20 @@ export class GameRoom {
     for (const botId of this._getQueuedAiBotIds()) {
       this._removeFromQueue(botId);
     }
+
+    if (!this._aiBotEnabled() || !this._openTextPromptsEnabled()) {
+      return;
+    }
+
+    const queuedHumans = this._countQueuedHumans();
+    if (queuedHumans === 0 || queuedHumans >= MIN_MATCH_SIZE) {
+      return;
+    }
+
+    const neededBots = MIN_MATCH_SIZE - queuedHumans;
+    for (let i = 0; i < neededBots; i += 1) {
+      this.waitingQueue.push(this._createAiBotId(i));
+    }
   }
 
   // -------------------------------------------------------------------------
@@ -955,14 +969,6 @@ export class GameRoom {
       this._failMatchStart(
         playerIds,
         'Public matches are unavailable until open-text prompts are enabled',
-      );
-      return;
-    }
-    if (aiAssisted) {
-      this._failMatchStart(
-        playerIds,
-        'AI-assisted matches are unavailable with the current mixed prompt catalog',
-        { retryMatchmaking: true },
       );
       return;
     }

--- a/test/worker/game-room-async.test.ts
+++ b/test/worker/game-room-async.test.ts
@@ -856,11 +856,12 @@ describe('GameRoom async task tracking', () => {
     ]);
   });
 
-  it('restores humans and rejects forced AI-assisted starts', async () => {
+  it('starts forced AI-assisted matches off the record', async () => {
     const { room } = createRoom({
       OPEN_TEXT_PROMPTS_ENABLED: 'true',
     });
-    vi.spyOn(room, '_broadcastQueueState').mockImplementation(() => {});
+    vi.spyOn(room, '_broadcastToMatch').mockImplementation(() => {});
+    vi.spyOn(room, '_checkpointMatch').mockImplementation(() => {});
 
     const alice = createConnectionState('Alice');
     const bob = createConnectionState('Bob');
@@ -873,21 +874,17 @@ describe('GameRoom async task tracking', () => {
       'match-ai-assisted',
     );
 
-    expect(room.activeMatches.size).toBe(0);
-    expect(room.waitingQueue).toEqual([]);
-    expect(room.formingMatch?.players).toEqual([
-      'acct-1',
-      'acct-2',
-      'acct-queued',
-    ]);
-    expect(alice.ws.send).toHaveBeenCalledWith(
+    expect(room.activeMatches.size).toBe(1);
+    expect(room.waitingQueue).toEqual(['acct-queued']);
+    expect(room.formingMatch).toBeNull();
+    expect(alice.ws.send).not.toHaveBeenCalledWith(
       JSON.stringify({
         type: 'error',
         message:
           'AI-assisted matches are unavailable with the current mixed prompt catalog',
       }),
     );
-    expect(bob.ws.send).toHaveBeenCalledWith(
+    expect(bob.ws.send).not.toHaveBeenCalledWith(
       JSON.stringify({
         type: 'error',
         message:
@@ -895,7 +892,18 @@ describe('GameRoom async task tracking', () => {
       }),
     );
 
-    if (room.formingMatch?.timer) clearTimeout(room.formingMatch.timer);
+    const match = must(
+      room.activeMatches.get('match-ai-assisted'),
+      'Expected AI-assisted match to start',
+    );
+    expect([...match.players.keys()]).toEqual([
+      'acct-1',
+      'ai-bot:0:test-bot',
+      'acct-2',
+    ]);
+    expect(match.aiAssisted).toBe(true);
+
+    if (match.commitTimer) clearTimeout(match.commitTimer);
   });
 
   it('starts the full reserved cohort when fill closes on 10 players', async () => {
@@ -1083,7 +1091,7 @@ describe('GameRoom async task tracking', () => {
     if (room.formingMatch?.timer) clearTimeout(room.formingMatch.timer);
   });
 
-  it('does not inject bots while waiting for the third human', async () => {
+  it('injects one bot once two humans are queued', async () => {
     const { room } = createRoom({
       AI_BOT_ENABLED: 'true',
       OPEN_TEXT_PROMPTS_ENABLED: 'true',
@@ -1096,9 +1104,16 @@ describe('GameRoom async task tracking', () => {
     await room._handleJoinQueue('acct-1');
     await room._handleJoinQueue('acct-2');
 
-    expect(room.formingMatch).toBeNull();
-    expect(room.waitingQueue).toEqual(['acct-1', 'acct-2']);
-    expect(room.waitingQueue.some((id) => room._isAiBot(id))).toBe(false);
+    expect(room.waitingQueue).toEqual([]);
+    expect(room.formingMatch).not.toBeNull();
+    expect(
+      room.formingMatch?.players.filter((id) => !room._isAiBot(id)),
+    ).toEqual(['acct-1', 'acct-2']);
+    expect(
+      room.formingMatch?.players.filter((id) => room._isAiBot(id)),
+    ).toHaveLength(1);
+
+    if (room.formingMatch?.timer) clearTimeout(room.formingMatch.timer);
   });
 
   it('forms a pure-human match when the third human arrives', async () => {
@@ -1124,7 +1139,7 @@ describe('GameRoom async task tracking', () => {
     if (room.formingMatch?.timer) clearTimeout(room.formingMatch.timer);
   });
 
-  it('does not inject bots for a solo human even when AI_BOT_ENABLED is true', async () => {
+  it('injects two bots for a solo human when AI_BOT_ENABLED is true', async () => {
     const { room } = createRoom({
       AI_BOT_ENABLED: 'true',
       OPEN_TEXT_PROMPTS_ENABLED: 'true',
@@ -1135,8 +1150,16 @@ describe('GameRoom async task tracking', () => {
 
     await room._handleJoinQueue('acct-1');
 
-    expect(room.formingMatch).toBeNull();
-    expect(room.waitingQueue).toEqual(['acct-1']);
+    expect(room.waitingQueue).toEqual([]);
+    expect(room.formingMatch).not.toBeNull();
+    expect(
+      room.formingMatch?.players.filter((id) => !room._isAiBot(id)),
+    ).toEqual(['acct-1']);
+    expect(
+      room.formingMatch?.players.filter((id) => room._isAiBot(id)),
+    ).toHaveLength(2);
+
+    if (room.formingMatch?.timer) clearTimeout(room.formingMatch.timer);
   });
 
   it('does not inject a bot for six humans', async () => {


### PR DESCRIPTION
## Summary
- restore limited AI queue backfill for 1- and 2-human public queues when `AI_BOT_ENABLED` is enabled
- allow AI-assisted matches to start again as off-the-record runs instead of rejecting them at match start
- update the queue/backfill tests and align the canonical rules and ADR log with the restored behavior

## Verification
- `npm test`
- `npm run typecheck`
- `npm run typecheck:worker`
- `npm run lint`