### PR TITLE
fix: correct landing page copy accuracy

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width,initial-scale=1"/>
 
 <!-- Primary SEO -->
-<title>The Schelling Game — Coordination Theory Meets On-Chain Play</title>
+<title>The Schelling Game — Coordination Theory Meets Crypto-Native Play</title>
 <meta name="description"
   content="Can you predict what strangers will choose? The Schelling Game is a commit-reveal coordination game inspired by Thomas Schelling's focal point theory. Play now — no install required."/>
 <link rel="canonical" href="https://schelling.games/"/>
@@ -43,7 +43,7 @@
   "@type": "WebApplication",
   "name": "The Schelling Game",
   "url": "https://schelling.games/",
-  "description": "A commit-reveal, on-chain coordination game inspired by Thomas Schelling's focal point theory. Players simultaneously commit secret choices, then reveal — plurality wins.",
+  "description": "A commit-reveal coordination game inspired by Thomas Schelling's focal point theory. Players simultaneously commit secret choices, then reveal — plurality wins.",
   "applicationCategory": "GameApplication",
   "browserRequirements": "Requires JavaScript. Requires an Ethereum-compatible browser wallet.",
   "inLanguage": "en",
@@ -853,7 +853,7 @@ footer{
       In 1960, economist Thomas Schelling posed a deceptively simple question:
       if two strangers had to meet in New York City with no way to communicate,
       where would they go? Most people said Grand Central Station at noon.
-      He called these natural meeting points <em>focal points</em> and proved that
+      He called these natural meeting points <em>focal points</em> and showed that
       coordination without communication is not only possible, it is predictable.
       Schelling won the 2005 Nobel Prize in Economics for his work on
       conflict and cooperation through game-theory analysis.
@@ -940,7 +940,7 @@ footer{
       <div class="mech-step reveal reveal-delay-4">
         <span class="icon">IV</span>
         <h3>Settle</h3>
-        <p>The plurality wins. Token ante is collected from all players, then redistributed to those who converged. Any indivisible remainder is burned.</p>
+        <p>The plurality wins. An ante is collected from all players, then redistributed to those who converged. Any indivisible remainder is burned.</p>
       </div>
     </div>
   </div>
@@ -1076,7 +1076,7 @@ footer{
     <!-- Why It Matters for Ethereum -->
     <div class="learn-subsection">
       <div class="section-label reveal">Ethereum Context</div>
-      <h2 class="section-title reveal">From theory to on-chain mechanism</h2>
+      <h2 class="section-title reveal">From theory to cryptographic mechanism</h2>
       <div class="learn-ethereum reveal">
         <p>
           In 2014, <strong>Vitalik Buterin proposed SchellingCoin</strong>: the first design
@@ -1106,7 +1106,7 @@ footer{
         <li>
           Roger Myerson &mdash;
           <a href="https://home.uchicago.edu/~rmyerson/stratofc2010.pdf" target="_blank" rel="noopener noreferrer">"Learning from Schelling's Strategy of Conflict"</a>
-          <span class="reading-year">2010</span>
+          <span class="reading-year">2009</span>
         </li>
         <li>
           Vitalik Buterin &mdash;


### PR DESCRIPTION
## Summary

- **"On-Chain Play" → "Crypto-Native Play"**: game runs on Cloudflare Workers + D1, not a blockchain; wallet auth (EIP-191) ≠ on-chain. Fixes title tag, ld+json description, and section heading.
- **"Token ante" → "An ante"**: ante is internal accounting units in D1, not an ERC-20 transfer.
- **"proved" → "showed"**: Schelling ran experiments, not formal proofs. Also resolves internal inconsistency with "showed experimentally" used later on the same page.
- **Myerson paper year 2010 → 2009**: published December 2009 in *Journal of Economic Literature*, vol. 47 no. 4.