### PR TITLE
feat: decouple prompt catalog size from match length

### DIFF
--- a/docs/adr/0010-ten-seed-ai-normalized-public-mode.md
+++ b/docs/adr/0010-ten-seed-ai-normalized-public-mode.md
@@ -1,6 +1,6 @@
 # ADR 0010: Ten-seed AI-normalized public mode
 
-Status: Accepted
+Status: Superseded by [ADR 0012](0012-decouple-catalog-from-match-length.md)
 Date: 2026-03-30
 
 Supersession note: This ADR supersedes ADR [0009](0009-hybrid-prompt-public-mode.md).

--- a/docs/adr/0012-decouple-catalog-from-match-length.md
+++ b/docs/adr/0012-decouple-catalog-from-match-length.md
@@ -1,0 +1,34 @@
+# ADR 0012: Decouple prompt catalog size from match length
+
+Status: Accepted
+Date: 2026-03-30
+
+Supersession note: This ADR supersedes ADR [0010](0010-ten-seed-ai-normalized-public-mode.md).
+
+## Context
+
+ADR 0010 established a fixed 10-prompt seed catalog where every public match uses all 10 prompts exactly once. This hard-coupled catalog size, match length, and prompt selection: the validator rejected pools that were not exactly 10 prompts, `selectPromptsForMatch` required `count === catalog.length`, and the ID range was hardcoded to 1001-1010.
+
+To grow the catalog toward 50 prompts (staged: 10, 20, 35, 50) while keeping matches at 10 games, the catalog size must be decoupled from the match length.
+
+A secondary gap: `canonicalExamples` on open-text prompts were consumed by AI bot generation and normalization prompts but never validated at catalog definition time.
+
+## Decision
+
+Catalog size is decoupled from match length via balanced sampling:
+
+- `MATCH_GAME_COUNT` (currently `10`) remains the sole authority on games per match.
+- `selectPromptsForMatch(count)` samples `floor(count/2)` select prompts and `count - floor(count/2)` open-text prompts from the catalog, then shuffles the combined sample.
+- Validators use minimums instead of exact counts: the catalog must contain at least `MATCH_GAME_COUNT` prompts with at least `ceil(MATCH_GAME_COUNT/2)` of each type.
+- Prompt IDs must be unique and positive but no longer require a contiguous range.
+- `canonicalExamples` on open-text prompts are validated at catalog definition time against both `validateAnswerText` and `canonicalizeOpenTextAnswer`.
+
+All other aspects of ADR 0010 remain in effect: Workers AI normalization is authoritative, the four-step open-text flow is preserved, and phase timings are unchanged.
+
+## Consequences
+
+- The catalog can grow beyond 10 prompts without changing match format.
+- Each match samples a balanced subset from the catalog; players see different prompt combinations across matches.
+- New prompts need a unique positive ID and a unique `PromptRoot` but not a contiguous ID range.
+- Invalid `canonicalExamples` are caught at catalog validation time, before they can bias AI behavior at runtime.
+- The staged expansion path (10, 20, 35, 50) can proceed with prompt-only changes; no further infrastructure work is needed.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -21,5 +21,6 @@ Format:
 | [0007](./0007-unanimous-start-now-for-forming-public-matches.md) | Unanimous start-now override for forming public matches | Accepted | 2026-03-29 |
 | [0008](./0008-remove-public-odd-match-requirement.md) | Remove public odd-match requirement | Accepted | 2026-03-29 |
 | [0009](./0009-hybrid-prompt-public-mode.md) | Hybrid prompt public mode | Superseded | 2026-03-29 |
-| [0010](./0010-ten-seed-ai-normalized-public-mode.md) | Ten-seed AI-normalized public mode | Accepted | 2026-03-30 |
+| [0010](./0010-ten-seed-ai-normalized-public-mode.md) | Ten-seed AI-normalized public mode | Superseded | 2026-03-30 |
 | [0011](./0011-restore-limited-ai-backfill.md) | Restore limited AI backfill for ten-seed public mode | Accepted | 2026-03-30 |
+| [0012](./0012-decouple-catalog-from-match-length.md) | Decouple prompt catalog size from match length | Accepted | 2026-03-30 |

--- a/docs/game-design.md
+++ b/docs/game-design.md
@@ -32,10 +32,9 @@ The intended skill is not specialist knowledge. It is identifying focal points t
 
 - Match size is any number from `3` to `21`.
 - Every match lasts `10` games unless it ends early under the rule in section 4.
-- Every match draws from the canonical public seed catalog of exactly `10` prompts:
-  - `5` `select` prompts: coin side, fruit, colour, day of week, planet
-  - `5` `open_text` prompts: number `1..10`, playing card, fair split keep amount, city, word
-- Every public human match uses all `10` prompts exactly once in shuffled order.
+- Every match draws `10` prompts from the canonical public prompt catalog (which may contain more than `10` prompts).
+- Each match sample contains an equal number of `select` and `open_text` prompts (`5` of each for `10`-game matches).
+- Prompts are sampled per type, then shuffled into a single match order.
 - `open_text` prompts are a hard prerequisite for public play. If `OPEN_TEXT_PROMPTS_ENABLED` is off, public matches do not start and the reserved cohort is restored to the waiting queue.
 - Limited AI backfill may raise a `1`- or `2`-human public queue to the minimum match size of `3`.
 - AI-assisted public matches remain off the record for this catalog: balances, streaks, and leaderboard standing do not change.
@@ -277,7 +276,7 @@ Canonical prompts may not rely on:
 
 Because settlement uses exact-match plurality or strict canonical bucket plurality, prompts should present salient coordination targets rather than requiring interpretation or specialist lookup.
 
-The current canonical pool is a fixed 10-prompt seed set designed to cover the main coordination archetypes without duplicative variants.
+The canonical prompt catalog is extensible beyond the initial 10-prompt seed set. Each match samples a balanced subset; the catalog may grow without changing match length.
 
 Prompt design rules:
 

--- a/src/domain/prompts.ts
+++ b/src/domain/prompts.ts
@@ -5,6 +5,9 @@ import type {
   SchellingPrompt,
   SelectPrompt,
 } from '../types/domain';
+import { validateAnswerText } from './commitReveal';
+import { MATCH_GAME_COUNT } from './constants';
+import { canonicalizeOpenTextAnswer } from './openText';
 
 export type PromptRoot =
   | 'coin_side'
@@ -231,9 +234,9 @@ function normalizeOptionIdentity(value: string): string {
 function getPromptIssues(pool: readonly SchellingPrompt[]): string[] {
   const issues: string[] = [];
 
-  if (pool.length !== 10) {
+  if (pool.length < MATCH_GAME_COUNT) {
     issues.push(
-      `Canonical prompt pool must contain exactly 10 prompts; found ${pool.length}.`,
+      `Prompt pool must contain at least ${MATCH_GAME_COUNT} prompts; found ${pool.length}.`,
     );
   }
 
@@ -273,17 +276,35 @@ function getPromptIssues(pool: readonly SchellingPrompt[]): string[] {
       if (!prompt.answerSpec?.kind) {
         issues.push(`Prompt ${prompt.id} must declare an answerSpec.`);
       }
+      if (!prompt.canonicalExamples || prompt.canonicalExamples.length === 0) {
+        issues.push(
+          `Prompt ${prompt.id} must declare at least one canonicalExample.`,
+        );
+      } else {
+        for (const example of prompt.canonicalExamples) {
+          if (!validateAnswerText(example, prompt)) {
+            issues.push(
+              `Prompt ${prompt.id} canonicalExample "${example}" fails answer validation.`,
+            );
+          } else if (!canonicalizeOpenTextAnswer(example, prompt)) {
+            issues.push(
+              `Prompt ${prompt.id} canonicalExample "${example}" fails canonicalization.`,
+            );
+          }
+        }
+      }
     }
   }
 
-  if (selectCount !== 5) {
+  const minPerType = Math.ceil(MATCH_GAME_COUNT / 2);
+  if (selectCount < minPerType) {
     issues.push(
-      `Canonical pool must contain exactly 5 select prompts; found ${selectCount}.`,
+      `Prompt pool must contain at least ${minPerType} select prompts; found ${selectCount}.`,
     );
   }
-  if (openTextCount !== 5) {
+  if (openTextCount < minPerType) {
     issues.push(
-      `Canonical pool must contain exactly 5 open_text prompts; found ${openTextCount}.`,
+      `Prompt pool must contain at least ${minPerType} open_text prompts; found ${openTextCount}.`,
     );
   }
 
@@ -308,16 +329,18 @@ function getRecordIssues(records: readonly PromptCatalogRecord[]): string[] {
     );
   }
 
-  const expectedIds = Array.from({ length: 10 }, (_, index) => 1001 + index);
-  for (const id of expectedIds) {
-    if (!ids.has(id)) {
-      issues.push(`Canonical prompt records must include prompt id ${id}.`);
+  for (const record of records) {
+    if (record.prompt.id <= 0) {
+      issues.push(`Prompt id must be positive; found ${record.prompt.id}.`);
     }
   }
+  if (ids.size !== records.length) {
+    issues.push('Canonical prompt records contain duplicate prompt ids.');
+  }
 
-  if (calibrationCount !== 1) {
+  if (calibrationCount < 1) {
     issues.push(
-      `Canonical prompt records must contain exactly one calibration prompt; found ${calibrationCount}.`,
+      `Canonical prompt records must contain at least one calibration prompt; found ${calibrationCount}.`,
     );
   }
 
@@ -339,7 +362,7 @@ export function getPromptRecordById(
 }
 
 export function selectPromptsForMatch(
-  count = 10,
+  count = MATCH_GAME_COUNT,
   options: { includeOpenText?: boolean } = {},
 ): SchellingPrompt[] {
   if (options.includeOpenText === false) {
@@ -348,15 +371,35 @@ export function selectPromptsForMatch(
     );
   }
 
-  if (count !== CANONICAL_PROMPT_RECORDS.length) {
+  if (count <= 0 || count > CANONICAL_PROMPT_RECORDS.length) {
     throw new RangeError(
-      `Current prompt catalog requires selecting all ${CANONICAL_PROMPT_RECORDS.length} prompts per match`,
+      `Cannot select ${count} prompts from a catalog of ${CANONICAL_PROMPT_RECORDS.length}`,
     );
   }
 
-  return shuffleInPlace([...CANONICAL_PROMPT_RECORDS]).map((record) =>
-    cloneJson(record.prompt),
+  const selectRecords = CANONICAL_PROMPT_RECORDS.filter(
+    (r) => r.prompt.type === 'select',
   );
+  const openTextRecords = CANONICAL_PROMPT_RECORDS.filter(
+    (r) => r.prompt.type === 'open_text',
+  );
+  const selectNeeded = Math.floor(count / 2);
+  const openTextNeeded = count - selectNeeded;
+
+  if (
+    selectRecords.length < selectNeeded ||
+    openTextRecords.length < openTextNeeded
+  ) {
+    throw new RangeError(
+      `Catalog lacks enough prompts of each type for a balanced ${count}-game match`,
+    );
+  }
+
+  const picked = [
+    ...shuffleInPlace([...selectRecords]).slice(0, selectNeeded),
+    ...shuffleInPlace([...openTextRecords]).slice(0, openTextNeeded),
+  ];
+  return shuffleInPlace(picked).map((record) => cloneJson(record.prompt));
 }
 
 export function getPromptPoolQualityIssues(

--- a/test/domain/prompts.test.ts
+++ b/test/domain/prompts.test.ts
@@ -33,30 +33,38 @@ describe('prompt pool', () => {
   const pool = getCanonicalPromptPool();
   const records = getCanonicalPromptRecords();
 
-  it('contains exactly 10 prompts', () => {
-    expect(pool).toHaveLength(10);
+  it('contains at least 10 prompts', () => {
+    expect(pool.length).toBeGreaterThanOrEqual(10);
   });
 
-  it('contains exactly 5 select prompts and 5 open-text prompts', () => {
-    expect(pool.filter((prompt) => prompt.type === 'select')).toHaveLength(5);
-    expect(pool.filter((prompt) => prompt.type === 'open_text')).toHaveLength(
-      5,
+  it('contains at least 5 select prompts and 5 open-text prompts', () => {
+    expect(
+      pool.filter((prompt) => prompt.type === 'select').length,
+    ).toBeGreaterThanOrEqual(5);
+    expect(
+      pool.filter((prompt) => prompt.type === 'open_text').length,
+    ).toBeGreaterThanOrEqual(5);
+  });
+
+  it('has unique positive ids and includes the original 10 seed prompts', () => {
+    const ids = records.map((record) => record.prompt.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const id of ids) {
+      expect(id).toBeGreaterThan(0);
+    }
+    for (let id = 1001; id <= 1010; id++) {
+      expect(ids).toContain(id);
+    }
+  });
+
+  it('contains one prompt per root and at least one calibration prompt', () => {
+    expect(new Set(records.map((record) => record.root)).size).toBe(
+      records.length,
     );
-  });
-
-  it('uses ids 1001 through 1010 in seed order', () => {
-    expect(records.map((record) => record.prompt.id)).toEqual([
-      1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009, 1010,
-    ]);
-  });
-
-  it('contains exactly one prompt per root and one calibration prompt', () => {
-    expect(new Set(records.map((record) => record.root)).size).toBe(10);
-    const calibrationIds = records
-      .filter((record) => record.calibration)
-      .map((record) => record.prompt.id);
-
-    expect(calibrationIds).toEqual([1001]);
+    const calibrationCount = records.filter(
+      (record) => record.calibration,
+    ).length;
+    expect(calibrationCount).toBeGreaterThanOrEqual(1);
   });
 
   it('assigns structured metadata to every open-text prompt', () => {
@@ -147,7 +155,7 @@ describe('prompt pool quality heuristics', () => {
     ).toBe(true);
   });
 
-  it('flags pools that break the 5 select / 5 open-text split', () => {
+  it('flags pools that break the minimum select / open-text balance', () => {
     const pool = getCanonicalPromptPool();
     const selectPrompt = pool.find(
       (prompt): prompt is Extract<SchellingPrompt, { type: 'select' }> =>
@@ -167,22 +175,20 @@ describe('prompt pool quality heuristics', () => {
     const issues = getPromptPoolQualityIssues(brokenPool);
 
     expect(
-      issues.some((issue) => issue.includes('exactly 5 select prompts')),
-    ).toBe(true);
-    expect(
-      issues.some((issue) => issue.includes('exactly 5 open_text prompts')),
+      issues.some((issue) => issue.includes('at least 5 open_text prompts')),
     ).toBe(true);
   });
 });
 
 describe('selectPromptsForMatch', () => {
-  it('returns all 10 prompts without duplicates', () => {
-    const selected = selectPromptsForMatch(10);
+  it('returns a balanced match sample', () => {
+    const selected = selectPromptsForMatch();
     expect(selected).toHaveLength(10);
     expect(new Set(selected.map((prompt) => prompt.id)).size).toBe(10);
-    expect(new Set(selected.map((prompt) => prompt.id))).toEqual(
-      new Set([1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009, 1010]),
-    );
+    const selectCount = selected.filter((p) => p.type === 'select').length;
+    const openTextCount = selected.filter((p) => p.type === 'open_text').length;
+    expect(selectCount).toBe(5);
+    expect(openTextCount).toBe(5);
   });
 
   it('rejects select-only matches for the mixed prompt catalog', () => {
@@ -191,9 +197,29 @@ describe('selectPromptsForMatch', () => {
     );
   });
 
-  it('rejects partial prompt selections', () => {
-    expect(() => selectPromptsForMatch(5)).toThrow(
-      'Current prompt catalog requires selecting all 10 prompts per match',
+  it('rejects counts larger than the catalog', () => {
+    const records = getCanonicalPromptRecords();
+    expect(() => selectPromptsForMatch(records.length + 1)).toThrow(
+      'Cannot select',
     );
+  });
+
+  it('flags open_text prompts with invalid canonicalExamples', () => {
+    const record = getMutableRecord(1006);
+    const snapshot = cloneJson(record);
+
+    try {
+      (record.prompt as OpenTextPrompt).canonicalExamples = [
+        'not a valid card',
+      ];
+      const issues = getPromptPoolQualityIssues();
+      expect(
+        issues.some((issue) =>
+          issue.includes('canonicalExample "not a valid card" fails'),
+        ),
+      ).toBe(true);
+    } finally {
+      restoreRecord(record, snapshot);
+    }
   });
 });


### PR DESCRIPTION
## Summary

The prompt catalog, validators, and sampling were hard-coupled to exactly 10 prompts, blocking catalog expansion toward 50. This patch decouples catalog size from match length as infrastructure for staged expansion (10 -> 20 -> 35 -> 50).

- **`selectPromptsForMatch`**: now samples a balanced subset (`floor(count/2)` select + remainder open_text) instead of requiring `count === catalog.length`
- **Validators**: use minimums (`>= MATCH_GAME_COUNT` prompts, `>= ceil(MATCH_GAME_COUNT/2)` per type) instead of exact counts
- **ID range**: hardcoded 1001-1010 range replaced with unique-positive-ID check
- **`canonicalExamples` validation**: open_text prompts now validated at catalog definition time against `validateAnswerText` and `canonicalizeOpenTextAnswer`
- **ADR 0012** supersedes ADR 0010; game-design.md updated

`MATCH_GAME_COUNT` stays at 10. With the current 10-prompt catalog, runtime behavior is identical.