### PR TITLE
[codex] Stop reconnect loops on socket handoff

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -1748,6 +1748,10 @@ function scheduleWebSocketReconnect() {
   }, delay);
 }
 
+function isSocketReplacementClose(evt) {
+  return evt && evt.code === 1000 && evt.reason === 'Replaced by new connection';
+}
+
 function stopWebSocketHeartbeat(targetSocket = null) {
   if (targetSocket && wsHeartbeatSocket !== targetSocket) return;
   if (wsHeartbeatTimer !== null) {
@@ -1866,13 +1870,18 @@ function connectWebSocket() {
     S.wsConnected = false;
     renderQueue();
   };
-  S.ws.onclose = () => {
+  S.ws.onclose = (evt) => {
     stopWebSocketHeartbeat(thisWs);
     if (thisWs === S.ws) {
       S.wsConnected = false;
       renderQueue();
     }
     if (intentionalClose || thisWs !== S.ws) return;
+    if (isSocketReplacementClose(evt)) {
+      wsQueueRecoveryPending = false;
+      notify('This session became active in another tab or window.', 'warn');
+      return;
+    }
     wsQueueRecoveryPending =
       S.inQueue && !hasActiveMatch() && S.pendingQueueAction !== 'leave';
     scheduleWebSocketReconnect();


### PR DESCRIPTION
## What changed
This follow-up patch stops the frontend from treating a normal WebSocket handoff as a transport failure.

## Why
The prior reconnect fix was already merged in #247. The remaining bug happened when the same session became active in another tab or window: the Durable Object intentionally closed the older socket with `Replaced by new connection`, but the client handled that like an unexpected outage and immediately started the `Connection lost. Reconnecting (1/10)...` loop.

## User impact
- the old tab no longer enters a reconnect loop when another tab/window takes over the same session
- users see a single warning explaining that the session became active elsewhere
- genuine network failures still use the normal reconnect path

## Root cause
The client's `onclose` handler did not distinguish between a worker-initiated socket replacement and a real connection loss.

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run typecheck:worker`
- `npm test`
- `npm run test:worker`
- reproduced with two simultaneous clients on the same session and verified the worker closes the old socket with `1000 / Replaced by new connection`