### PR TITLE
[codex] Improve playing card picker

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -2381,7 +2381,7 @@ function renderPromptInput(prompt, disabled) {
   }
 
   if (prompt.answerSpec.kind === 'playing_card') {
-    renderPlayingCardInput(disabled, grid);
+    renderPlayingCardInput(prompt, disabled, grid);
     return;
   }
 
@@ -2426,7 +2426,7 @@ function renderPromptInput(prompt, disabled) {
   grid.appendChild(wrap);
 }
 
-function renderPlayingCardInput(disabled, grid) {
+function renderPlayingCardInput(prompt, disabled, grid) {
   const wrap = document.createElement('div');
   wrap.className = 'text-answer-wrap';
   wrap.style.gridColumn = '1 / -1';
@@ -2488,9 +2488,21 @@ function renderPlayingCardInput(disabled, grid) {
     if (S.committed || S.phase !== 'commit') return;
     syncPlayingCardSelection();
   });
+  rankSelect.addEventListener('keydown', (event) => {
+    if (!shouldHandleCommitShortcut(event)) return;
+    if (!validateOpenTextAnswer(S.selectedAnswerText, prompt)) return;
+    event.preventDefault();
+    void submitCommit();
+  });
   suitSelect.addEventListener('change', () => {
     if (S.committed || S.phase !== 'commit') return;
     syncPlayingCardSelection();
+  });
+  suitSelect.addEventListener('keydown', (event) => {
+    if (!shouldHandleCommitShortcut(event)) return;
+    if (!validateOpenTextAnswer(S.selectedAnswerText, prompt)) return;
+    event.preventDefault();
+    void submitCommit();
   });
 
   const rankField = document.createElement('label');


### PR DESCRIPTION
## What changed
Replaced the free-text playing-card answer input with paired rank and suit dropdowns in the browser UI.

## Why
Players could get lost on the `Pick a playing card` prompt because they had to type a valid card format manually. The new picker narrows the choice to a valid rank/suit combination while still preserving the canonical commit/reveal answer text.

## Impact
The prompt is easier to answer correctly on desktop and mobile, while reconnects and existing card aliases still resolve back to the same canonical card value.

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run typecheck:worker`
- `npm test`