### PR TITLE
[codex] Add tacit coordination paper references

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ GitHub Actions workflows currently do the following:
 ## Background
 
 - [Schelling Coordination in LLMs: A Review](https://www.lesswrong.com/posts/tJKNXCxx7ZKD5mtG9/schelling-coordination-in-llms-a-review)
+- [Tacit Coordination of Large Language Models](https://arxiv.org/abs/2601.22184)
 - [Secret Collusion among AI Agents: Multi-Agent Deception via Steganography](https://arxiv.org/abs/2402.07510)
 - [Subversion via Focal Points: Investigating Collusion in LLM Monitoring](https://arxiv.org/abs/2507.03010)
 

--- a/public/index.html
+++ b/public/index.html
@@ -1155,6 +1155,11 @@ footer{
           <a href="https://www.alignmentforum.org/posts/n2c62YS8RJtD4Aqhh/schelling-game-evaluations-for-ai-control" target="_blank" rel="noopener noreferrer">"Schelling game evaluations for AI control"</a>
           <span class="reading-year">2024</span>
         </li>
+        <li>
+          Aharon et al. &mdash;
+          <a href="https://arxiv.org/abs/2601.22184" target="_blank" rel="noopener noreferrer">"Tacit Coordination of Large Language Models"</a>
+          <span class="reading-year">2026</span>
+        </li>
       </ul>
     </details>
 


### PR DESCRIPTION
## What changed

- added `Tacit Coordination of Large Language Models` to the README background links
- added the same paper to the landing page `Further Reading` section
- updated issue #246 from a bare URL into a concrete tracking issue and linked its actionable follow-up to #250

## Why

Issue #246 identified this paper as important enough to act on. The repo already has literature surfaces for background context and further reading, so the immediate product-facing action is to list the paper there and connect it to the existing AI calibration follow-up.

## Impact

- the paper is now visible to readers in both the repository docs and the public site
- the GitHub issue is now actionable instead of just storing a link
- future work on AI backfill calibration has an explicit literature anchor in #250

## Validation

- `npx biome check .`