### PR TITLE
feat: reject mismatched client builds at queue/forming admission (#251)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,7 +246,7 @@ jobs:
           PREVIEW_WORKER_NAME: ${{ steps.preview.outputs.worker_name }}
         run: |
           set -euo pipefail
-          deploy_output="$(npx wrangler deploy --config wrangler.preview.toml --secrets-file preview.secrets.env 2>&1 | tee /dev/stderr)"
+          deploy_output="$(npx wrangler deploy --config wrangler.preview.toml --secrets-file preview.secrets.env --var "BUILD_HASH:$(git rev-parse --short HEAD)" 2>&1 | tee /dev/stderr)"
           preview_url="$(printf '%s\n' "$deploy_output" | grep -Eo 'https://[^[:space:]]+' | grep 'workers.dev' | tail -n 1 || true)"
 
           if [ -z "$preview_url" ]; then

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -47,7 +47,7 @@ jobs:
           attempts=3
           for attempt in $(seq 1 "$attempts"); do
             log_file="$(mktemp)"
-            if npx wrangler deploy 2>&1 | tee "$log_file"; then
+            if npx wrangler deploy --var "BUILD_HASH:$(git rev-parse --short HEAD)" 2>&1 | tee "$log_file"; then
               rm -f "$log_file"
               exit 0
             fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
           attempts=3
           for attempt in $(seq 1 "$attempts"); do
             log_file="$(mktemp)"
-            if npx wrangler deploy --env next 2>&1 | tee "$log_file"; then
+            if npx wrangler deploy --env next --var "BUILD_HASH:$(git rev-parse --short HEAD)" 2>&1 | tee "$log_file"; then
               rm -f "$log_file"
               exit 0
             fi

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "typecheck:worker": "tsc --noEmit -p tsconfig.worker.json",
     "stamp-build": "sed -i.bak -e \"s/__BUILD_HASH__/$(git rev-parse --short HEAD)/\" -e \"s/__BUILD_DATE__/$(date -u +%Y-%m-%dT%H:%MZ)/\" public/index.html public/app.html",
     "unstamp-build": "mv public/index.html.bak public/index.html && mv public/app.html.bak public/app.html",
-    "deploy": "sh -c 'set -e; wrangler_backup=$(mktemp); cp wrangler.toml \"$wrangler_backup\"; cleanup(){ npm run unstamp-build >/dev/null 2>&1 || true; if [ -f \"$wrangler_backup\" ]; then cp \"$wrangler_backup\" wrangler.toml; rm -f \"$wrangler_backup\"; fi; }; trap cleanup EXIT; npm run sync:ai-bot-pool; npm run stamp-build; CLOUDFLARE_API_TOKEN=${CLOUDFLARE_FERIT_API_TOKEN:-$CLOUDFLARE_API_TOKEN} npx wrangler deploy; trap - EXIT; cleanup'"
+    "deploy": "sh -c 'set -e; wrangler_backup=$(mktemp); cp wrangler.toml \"$wrangler_backup\"; cleanup(){ npm run unstamp-build >/dev/null 2>&1 || true; if [ -f \"$wrangler_backup\" ]; then cp \"$wrangler_backup\" wrangler.toml; rm -f \"$wrangler_backup\"; fi; }; trap cleanup EXIT; npm run sync:ai-bot-pool; npm run stamp-build; CLOUDFLARE_API_TOKEN=${CLOUDFLARE_FERIT_API_TOKEN:-$CLOUDFLARE_API_TOKEN} npx wrangler deploy --var \"BUILD_HASH:$(git rev-parse --short HEAD)\"; trap - EXIT; cleanup'"
   },
   "repository": {
     "type": "git",

--- a/public/scripts/app.js
+++ b/public/scripts/app.js
@@ -829,6 +829,34 @@ function isSocketReplacementClose(evt) {
   return evt && evt.code === 1000 && evt.reason === 'Replaced by new connection';
 }
 
+function isBuildMismatchClose(evt) {
+  return evt && evt.code === 4001;
+}
+
+function readStampedClientBuild() {
+  try {
+    const stamp = document.querySelector('.build-stamp');
+    const hash = stamp ? stamp.getAttribute('data-build-hash') : null;
+    if (!hash || hash === '__BUILD_HASH__') return null;
+    return /^[a-f0-9]{7,40}$/.test(hash) ? hash : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+function showTerminalClose(message) {
+  try {
+    const host = document.getElementById('notif');
+    if (!host) return;
+    const existing = host.querySelector('.notif-item.terminal');
+    if (existing) return;
+    const el = document.createElement('div');
+    el.className = 'notif-item error terminal';
+    el.textContent = message;
+    host.appendChild(el);
+  } catch (_) {}
+}
+
 function stopWebSocketHeartbeat(targetSocket = null) {
   if (targetSocket && wsHeartbeatSocket !== targetSocket) return;
   if (wsHeartbeatTimer !== null) {
@@ -944,7 +972,11 @@ function connectWebSocket() {
   S.wsConnected = false;
   stopWebSocketHeartbeat();
   const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
-  S.ws = new WebSocket(`${proto}//${location.host}/ws`);
+  const clientBuild = readStampedClientBuild();
+  const wsUrl = clientBuild
+    ? `${proto}//${location.host}/ws?clientBuild=${encodeURIComponent(clientBuild)}`
+    : `${proto}//${location.host}/ws`;
+  S.ws = new WebSocket(wsUrl);
   const thisWs = S.ws;
   renderQueue();
   S.ws.onopen = () => {
@@ -975,7 +1007,20 @@ function connectWebSocket() {
     if (intentionalClose || thisWs !== S.ws) return;
     if (isSocketReplacementClose(evt)) {
       wsQueueRecoveryPending = false;
-      notify('This session became active in another tab or window.', 'warn');
+      showTerminalClose(
+        'This session became active in another tab or window.',
+      );
+      return;
+    }
+    if (isBuildMismatchClose(evt)) {
+      intentionalClose = true;
+      wsQueueRecoveryPending = false;
+      S.pendingQueueAction = null;
+      clearWebSocketRetryTimer();
+      showTerminalClose(
+        'A new version is available. Refresh this page to continue.',
+      );
+      renderQueue();
       return;
     }
     wsQueueRecoveryPending =

--- a/public/scripts/app.js
+++ b/public/scripts/app.js
@@ -849,7 +849,10 @@ function showTerminalClose(message) {
     const host = document.getElementById('notif');
     if (!host) return;
     const existing = host.querySelector('.notif-item.terminal');
-    if (existing) return;
+    if (existing) {
+      existing.textContent = message;
+      return;
+    }
     const el = document.createElement('div');
     el.className = 'notif-item error terminal';
     el.textContent = message;

--- a/public/scripts/app.js
+++ b/public/scripts/app.js
@@ -764,6 +764,10 @@ let wsHeartbeatSocket = null;
 let wsAwaitingPong = false;
 let wsReconnectPaused = false;
 let wsQueueRecoveryPending = false;
+// Latched on a 4001 close; only a page refresh (script re-eval) clears it.
+let buildMismatchTerminal = false;
+const STALE_BUILD_REFRESH_MESSAGE =
+  'A new version is available. Refresh this page to continue.';
 
 function clearWebSocketRetryTimer() {
   if (wsRetryTimer !== null) {
@@ -941,6 +945,10 @@ function refreshLiveWebSocketIdentity() {
 }
 
 function queueQueueAction(action) {
+  if (buildMismatchTerminal) {
+    showTerminalClose(STALE_BUILD_REFRESH_MESSAGE);
+    return;
+  }
   const isNewAction = S.pendingQueueAction !== action;
   S.pendingQueueAction = action;
   renderQueue();
@@ -969,6 +977,7 @@ function flushPendingQueueAction() {
 }
 
 function connectWebSocket() {
+  if (buildMismatchTerminal) return;
   if (!S.accountId) return;
   wsReconnectPaused = false;
   wsRetryTimer = null;
@@ -1016,13 +1025,12 @@ function connectWebSocket() {
       return;
     }
     if (isBuildMismatchClose(evt)) {
+      buildMismatchTerminal = true;
       intentionalClose = true;
       wsQueueRecoveryPending = false;
       S.pendingQueueAction = null;
       clearWebSocketRetryTimer();
-      showTerminalClose(
-        'A new version is available. Refresh this page to continue.',
-      );
+      showTerminalClose(STALE_BUILD_REFRESH_MESSAGE);
       renderQueue();
       return;
     }

--- a/scripts/smoke-remote.mjs
+++ b/scripts/smoke-remote.mjs
@@ -107,6 +107,10 @@ async function waitForReady() {
         typeof payload.revealDuration === 'number',
         'game-config missing revealDuration',
       );
+      assert(
+        typeof payload.build === 'string' && payload.build.length > 0,
+        'game-config missing build hash',
+      );
       return;
     } catch (error) {
       lastError = error;

--- a/scripts/smoke-remote.mjs
+++ b/scripts/smoke-remote.mjs
@@ -185,6 +185,10 @@ await expectHtmlEventually('/app', 'Schelling Games');
 await expectJson('/api/game-config', undefined, (payload) => {
   assert(payload.commitDuration === 60, 'unexpected commitDuration');
   assert(payload.revealDuration === 15, 'unexpected revealDuration');
+  assert(
+    typeof payload.build === 'string' && payload.build.length > 0,
+    'game-config missing build hash',
+  );
 });
 
 await expectJson('/api/landing-stats', undefined, (payload) => {

--- a/scripts/smoke-remote.mjs
+++ b/scripts/smoke-remote.mjs
@@ -8,6 +8,10 @@ if (!baseUrl) {
 
 const base = new URL(baseUrl);
 
+// Mirrors BUILD_HASH_RE in src/worker/gameRoom/index.ts: a deployed build
+// value outside this shape disables the admission gate (it fails open).
+const BUILD_HASH_RE = /^[a-f0-9]{7,40}$/;
+
 function assert(condition, message) {
   if (!condition) {
     throw new Error(message);
@@ -108,8 +112,8 @@ async function waitForReady() {
         'game-config missing revealDuration',
       );
       assert(
-        typeof payload.build === 'string' && payload.build.length > 0,
-        'game-config missing build hash',
+        typeof payload.build === 'string' && BUILD_HASH_RE.test(payload.build),
+        'game-config build is not a git sha (admission gate would be disabled)',
       );
       return;
     } catch (error) {
@@ -190,8 +194,8 @@ await expectJson('/api/game-config', undefined, (payload) => {
   assert(payload.commitDuration === 60, 'unexpected commitDuration');
   assert(payload.revealDuration === 15, 'unexpected revealDuration');
   assert(
-    typeof payload.build === 'string' && payload.build.length > 0,
-    'game-config missing build hash',
+    typeof payload.build === 'string' && BUILD_HASH_RE.test(payload.build),
+    'game-config build is not a git sha (admission gate would be disabled)',
   );
 });
 

--- a/src/types/worker-env.ts
+++ b/src/types/worker-env.ts
@@ -27,4 +27,5 @@ export interface Env {
   OPEN_TEXT_NORMALIZER_TIMEOUT_MS?: string;
   TURNSTILE_SECRET_KEY?: string;
   TURNSTILE_SITE_KEY?: string;
+  BUILD_HASH?: string;
 }

--- a/src/worker/gameRoom/index.ts
+++ b/src/worker/gameRoom/index.ts
@@ -66,7 +66,12 @@ interface ConnectionState {
   previousOpponents: Set<string>;
   lastActivityAt: number;
   livenessTimer: ReturnType<typeof setInterval> | null;
+  clientBuild: string | null;
 }
+
+// UX hint against accidentally stale client bundles — NOT an auth boundary.
+// A tampered client can still forge this value; the ws protocol itself is open.
+const CLIENT_BUILD_HASH_RE = /^[a-f0-9]{7,40}$/;
 
 interface WorkerPlayerState extends PersistedPlayerState {
   ws: WebSocket | null;
@@ -269,6 +274,7 @@ export class GameRoom {
         url.searchParams.get('tokenBalance') || '0',
         10,
       );
+      const clientBuild = url.searchParams.get('clientBuild');
 
       if (!accountId || !displayName) {
         return new Response('Missing auth params', { status: 400 });
@@ -276,7 +282,13 @@ export class GameRoom {
 
       const pair = new WebSocketPair();
       const [client, server] = [pair[0], pair[1]];
-      this._handleWebSocket(server, accountId, displayName, tokenBalance);
+      this._handleWebSocket(
+        server,
+        accountId,
+        displayName,
+        tokenBalance,
+        clientBuild,
+      );
       return new Response(null, { status: 101, webSocket: client });
     }
 
@@ -292,6 +304,7 @@ export class GameRoom {
     accountId: string,
     displayName: string,
     _tokenBalance: number,
+    clientBuild: string | null,
   ): void {
     ws.accept();
 
@@ -361,6 +374,7 @@ export class GameRoom {
             previousOpponents: new Set(),
             lastActivityAt: Date.now(),
             livenessTimer: null,
+            clientBuild: null,
           });
           if (playerState.graceTimer) {
             clearTimeout(playerState.graceTimer);
@@ -397,6 +411,23 @@ export class GameRoom {
       }
     }
 
+    // Build-mismatch guard at the queue/forming boundary. Active-match
+    // reconnects above are grandfathered (all players in a live match share a
+    // build). Fresh queue joins and queue/forming reconnects must match the
+    // deployed build so they cannot mix message shapes with newer clients.
+    const clientBuildValid =
+      typeof clientBuild === 'string' && CLIENT_BUILD_HASH_RE.test(clientBuild);
+    if (
+      this.env.BUILD_HASH &&
+      (!clientBuildValid || clientBuild !== this.env.BUILD_HASH)
+    ) {
+      try {
+        ws.close(4001, 'client build mismatch');
+      } catch {}
+      return;
+    }
+    const acceptedClientBuild = clientBuildValid ? clientBuild : null;
+
     const inFormingMatch =
       this.formingMatch?.players.includes(accountId) ?? false;
     const queuedConnection =
@@ -409,6 +440,7 @@ export class GameRoom {
       this._clearConnectionLivenessMonitor(accountId);
       existingConn.ws = ws;
       existingConn.displayName = displayName;
+      existingConn.clientBuild = acceptedClientBuild;
       if (!inFormingMatch) {
         existingConn.startNow = false;
       }
@@ -442,6 +474,7 @@ export class GameRoom {
         : new Set(),
       lastActivityAt: Date.now(),
       livenessTimer: null,
+      clientBuild: acceptedClientBuild,
     });
 
     this._setupWsListeners(ws, accountId);

--- a/src/worker/gameRoom/index.ts
+++ b/src/worker/gameRoom/index.ts
@@ -70,7 +70,9 @@ interface ConnectionState {
 
 // UX hint against accidentally stale client bundles — NOT an auth boundary.
 // A tampered client can still forge this value; the ws protocol itself is open.
-const CLIENT_BUILD_HASH_RE = /^[a-f0-9]{7,40}$/;
+// Validates both the deployed BUILD_HASH and the client-sent value: a
+// misconfigured server value disables the gate instead of rejecting everyone.
+const BUILD_HASH_RE = /^[a-f0-9]{7,40}$/;
 
 interface WorkerPlayerState extends PersistedPlayerState {
   ws: WebSocket | null;
@@ -416,11 +418,14 @@ export class GameRoom {
     // reconnects above are grandfathered (all players in a live match share a
     // build). Fresh queue joins and queue/forming reconnects must match the
     // deployed build so they cannot mix message shapes with newer clients.
-    const buildHash = this.env.BUILD_HASH?.trim();
+    const rawBuildHash = this.env.BUILD_HASH?.trim();
+    const buildHash =
+      rawBuildHash && BUILD_HASH_RE.test(rawBuildHash)
+        ? rawBuildHash
+        : undefined;
     if (buildHash) {
       const clientBuildValid =
-        typeof clientBuild === 'string' &&
-        CLIENT_BUILD_HASH_RE.test(clientBuild);
+        typeof clientBuild === 'string' && BUILD_HASH_RE.test(clientBuild);
       if (!clientBuildValid || clientBuild !== buildHash) {
         try {
           ws.close(4001, 'client build mismatch');
@@ -428,11 +433,14 @@ export class GameRoom {
         return;
       }
     } else if (!this.buildGateDisabledWarned) {
-      // Fails open by design: rejecting everyone on a missing var would take
-      // queueing down entirely. Expected unset only under `wrangler dev`.
+      // Fails open by design: rejecting everyone on a missing or mistyped var
+      // would take queueing down entirely. Expected unset under `wrangler dev`.
       this.buildGateDisabledWarned = true;
+      const reason = rawBuildHash
+        ? `BUILD_HASH ${JSON.stringify(rawBuildHash)} is not a git short sha`
+        : 'BUILD_HASH is unset';
       console.warn(
-        'BUILD_HASH is unset: client build admission gate is disabled. ' +
+        `${reason}: client build admission gate is disabled. ` +
           'Deploys must pass --var BUILD_HASH:<git short sha>.',
       );
     }

--- a/src/worker/gameRoom/index.ts
+++ b/src/worker/gameRoom/index.ts
@@ -437,11 +437,11 @@ export class GameRoom {
       // would take queueing down entirely. Expected unset under `wrangler dev`.
       this.buildGateDisabledWarned = true;
       const reason = rawBuildHash
-        ? `BUILD_HASH ${JSON.stringify(rawBuildHash)} is not a git short sha`
+        ? `BUILD_HASH ${JSON.stringify(rawBuildHash)} is not a git sha`
         : 'BUILD_HASH is unset';
       console.warn(
         `${reason}: client build admission gate is disabled. ` +
-          'Deploys must pass --var BUILD_HASH:<git short sha>.',
+          'Deploys must pass --var BUILD_HASH:<git sha>.',
       );
     }
 

--- a/src/worker/gameRoom/index.ts
+++ b/src/worker/gameRoom/index.ts
@@ -66,7 +66,6 @@ interface ConnectionState {
   previousOpponents: Set<string>;
   lastActivityAt: number;
   livenessTimer: ReturnType<typeof setInterval> | null;
-  clientBuild: string | null;
 }
 
 // UX hint against accidentally stale client bundles — NOT an auth boundary.
@@ -241,6 +240,8 @@ export class GameRoom {
   // Quick lookup: accountId -> matchId
   playerMatchIndex: Map<string, string>;
 
+  buildGateDisabledWarned: boolean;
+
   constructor(state: DurableObjectState, env: Env) {
     this.state = state;
     this.env = env;
@@ -251,6 +252,7 @@ export class GameRoom {
     this.formingMatch = null;
     this.activeMatches = new Map();
     this.playerMatchIndex = new Map();
+    this.buildGateDisabledWarned = false;
 
     initCheckpointTables(this.state.storage.sql);
     this._restoreMatchesFromStorage();
@@ -374,7 +376,6 @@ export class GameRoom {
             previousOpponents: new Set(),
             lastActivityAt: Date.now(),
             livenessTimer: null,
-            clientBuild: null,
           });
           if (playerState.graceTimer) {
             clearTimeout(playerState.graceTimer);
@@ -415,18 +416,25 @@ export class GameRoom {
     // reconnects above are grandfathered (all players in a live match share a
     // build). Fresh queue joins and queue/forming reconnects must match the
     // deployed build so they cannot mix message shapes with newer clients.
-    const clientBuildValid =
-      typeof clientBuild === 'string' && CLIENT_BUILD_HASH_RE.test(clientBuild);
-    if (
-      this.env.BUILD_HASH &&
-      (!clientBuildValid || clientBuild !== this.env.BUILD_HASH)
-    ) {
-      try {
-        ws.close(4001, 'client build mismatch');
-      } catch {}
-      return;
+    if (this.env.BUILD_HASH) {
+      const clientBuildValid =
+        typeof clientBuild === 'string' &&
+        CLIENT_BUILD_HASH_RE.test(clientBuild);
+      if (!clientBuildValid || clientBuild !== this.env.BUILD_HASH) {
+        try {
+          ws.close(4001, 'client build mismatch');
+        } catch {}
+        return;
+      }
+    } else if (!this.buildGateDisabledWarned) {
+      // Fails open by design: rejecting everyone on a missing var would take
+      // queueing down entirely. Expected unset only under `wrangler dev`.
+      this.buildGateDisabledWarned = true;
+      console.warn(
+        'BUILD_HASH is unset: client build admission gate is disabled. ' +
+          'Deploys must pass --var BUILD_HASH:<git short sha>.',
+      );
     }
-    const acceptedClientBuild = clientBuildValid ? clientBuild : null;
 
     const inFormingMatch =
       this.formingMatch?.players.includes(accountId) ?? false;
@@ -440,7 +448,6 @@ export class GameRoom {
       this._clearConnectionLivenessMonitor(accountId);
       existingConn.ws = ws;
       existingConn.displayName = displayName;
-      existingConn.clientBuild = acceptedClientBuild;
       if (!inFormingMatch) {
         existingConn.startNow = false;
       }
@@ -474,7 +481,6 @@ export class GameRoom {
         : new Set(),
       lastActivityAt: Date.now(),
       livenessTimer: null,
-      clientBuild: acceptedClientBuild,
     });
 
     this._setupWsListeners(ws, accountId);

--- a/src/worker/gameRoom/index.ts
+++ b/src/worker/gameRoom/index.ts
@@ -416,11 +416,12 @@ export class GameRoom {
     // reconnects above are grandfathered (all players in a live match share a
     // build). Fresh queue joins and queue/forming reconnects must match the
     // deployed build so they cannot mix message shapes with newer clients.
-    if (this.env.BUILD_HASH) {
+    const buildHash = this.env.BUILD_HASH?.trim();
+    if (buildHash) {
       const clientBuildValid =
         typeof clientBuild === 'string' &&
         CLIENT_BUILD_HASH_RE.test(clientBuild);
-      if (!clientBuildValid || clientBuild !== this.env.BUILD_HASH) {
+      if (!clientBuildValid || clientBuild !== buildHash) {
         try {
           ws.close(4001, 'client build mismatch');
         } catch {}

--- a/src/worker/httpHandler.ts
+++ b/src/worker/httpHandler.ts
@@ -44,6 +44,12 @@ export async function handleHttpRequest(
     doUrl.searchParams.set('accountId', accountId);
     doUrl.searchParams.set('displayName', displayName);
     doUrl.searchParams.set('tokenBalance', String(account.token_balance ?? 0));
+    const rawClientBuild = url.searchParams.get('clientBuild');
+    if (rawClientBuild && rawClientBuild.length <= 64) {
+      doUrl.searchParams.set('clientBuild', rawClientBuild);
+    } else {
+      doUrl.searchParams.delete('clientBuild');
+    }
     return stub.fetch(new Request(doUrl.toString(), request));
   }
 

--- a/src/worker/routes/landing.ts
+++ b/src/worker/routes/landing.ts
@@ -201,6 +201,7 @@ export function handleGameConfig(_request: Request, env: Env): Response {
     commitDuration: COMMIT_DURATION,
     revealDuration: REVEAL_DURATION,
     turnstileSiteKey: getConfiguredTurnstileSiteKey(env),
+    build: env.BUILD_HASH ?? null,
   });
 }
 

--- a/src/worker/routes/landing.ts
+++ b/src/worker/routes/landing.ts
@@ -201,7 +201,7 @@ export function handleGameConfig(_request: Request, env: Env): Response {
     commitDuration: COMMIT_DURATION,
     revealDuration: REVEAL_DURATION,
     turnstileSiteKey: getConfiguredTurnstileSiteKey(env),
-    build: env.BUILD_HASH ?? null,
+    build: env.BUILD_HASH?.trim() || null,
   });
 }
 

--- a/test/worker/game-room.test.ts
+++ b/test/worker/game-room.test.ts
@@ -199,9 +199,15 @@ function waitForMessageWhere(
   });
 }
 
-async function openWs(cookie: string): Promise<WebSocket> {
+async function openWs(
+  cookie: string,
+  clientBuild?: string,
+): Promise<WebSocket> {
+  const url = clientBuild
+    ? `${BASE}/ws?clientBuild=${encodeURIComponent(clientBuild)}`
+    : `${BASE}/ws`;
   const resp = await exports.default.fetch(
-    new Request(`${BASE}/ws`, {
+    new Request(url, {
       headers: {
         Upgrade: 'websocket',
         Cookie: `session=${cookie}`,
@@ -339,6 +345,85 @@ describe('GameRoom Durable Object', () => {
       }),
     );
     expect(resp.status).toBe(401);
+  });
+
+  describe('client build admission', () => {
+    const buildEnv = env as unknown as { BUILD_HASH?: string };
+    const CURRENT_BUILD = 'deadbee';
+    let previousBuildHash: string | undefined;
+
+    beforeEach(() => {
+      previousBuildHash = buildEnv.BUILD_HASH;
+      buildEnv.BUILD_HASH = CURRENT_BUILD;
+    });
+
+    afterEach(() => {
+      if (previousBuildHash === undefined) {
+        delete buildEnv.BUILD_HASH;
+      } else {
+        buildEnv.BUILD_HASH = previousBuildHash;
+      }
+    });
+
+    it('admits a client whose build matches the deployed build', async () => {
+      const wallet = createTestWallet(20);
+      const { accountId, cookie } = await createTestSession(wallet);
+      await seedAccount(env.DB, accountId, 'MatchingBuildPlayer');
+      const ws = await openWs(cookie, CURRENT_BUILD);
+      const queueMsg = await waitForMessage(ws, 'queue_state', 3000);
+      expect(queueMsg.type).toBe('queue_state');
+      ws.close();
+    });
+
+    it('closes a client with a mismatched build (code 4001)', async () => {
+      const wallet = createTestWallet(21);
+      const { accountId, cookie } = await createTestSession(wallet);
+      await seedAccount(env.DB, accountId, 'StalePlayer');
+      const ws = await openWs(cookie, 'abc1234');
+      const closed = await waitForClose(ws, 3000);
+      expect(closed.code).toBe(4001);
+      expect(closed.reason).toBe('client build mismatch');
+    });
+
+    it('closes a client with a malformed build (code 4001)', async () => {
+      const wallet = createTestWallet(22);
+      const { accountId, cookie } = await createTestSession(wallet);
+      await seedAccount(env.DB, accountId, 'MalformedPlayer');
+      const ws = await openWs(cookie, 'not-a-hex-sha!!');
+      const closed = await waitForClose(ws, 3000);
+      expect(closed.code).toBe(4001);
+      expect(closed.reason).toBe('client build mismatch');
+    });
+
+    it('closes a client when BUILD_HASH is set but no clientBuild is sent', async () => {
+      const wallet = createTestWallet(23);
+      const { accountId, cookie } = await createTestSession(wallet);
+      await seedAccount(env.DB, accountId, 'NoBuildPlayer');
+      const ws = await openWs(cookie);
+      const closed = await waitForClose(ws, 3000);
+      expect(closed.code).toBe(4001);
+    });
+  });
+
+  it('skips build-mismatch check when env.BUILD_HASH is unset', async () => {
+    const buildEnv = env as unknown as { BUILD_HASH?: string };
+    const previous = buildEnv.BUILD_HASH;
+    delete buildEnv.BUILD_HASH;
+    try {
+      const wallet = createTestWallet(24);
+      const { accountId, cookie } = await createTestSession(wallet);
+      await seedAccount(env.DB, accountId, 'DevModePlayer');
+      const ws = await openWs(cookie, 'anything-goes');
+      const queueMsg = await waitForMessage(ws, 'queue_state', 3000);
+      expect(queueMsg.type).toBe('queue_state');
+      ws.close();
+    } finally {
+      if (previous === undefined) {
+        delete buildEnv.BUILD_HASH;
+      } else {
+        buildEnv.BUILD_HASH = previous;
+      }
+    }
   });
 
   it('WebSocket auto-provisions a missing account for a valid session', async () => {
@@ -825,6 +910,66 @@ describe('GameRoom Durable Object', () => {
     p1r.ws.close();
     p2.ws.close();
     p3.ws.close();
+  });
+
+  it('grandfathers mid-match reconnect with a stale client build', {
+    timeout: 55_000,
+  }, async () => {
+    const buildEnv = env as unknown as { BUILD_HASH?: string };
+    const previousBuildHash = buildEnv.BUILD_HASH;
+    delete buildEnv.BUILD_HASH;
+    try {
+      const p1 = await connectPlayer(25, 'GrandfatherP1');
+      const p2 = await connectPlayer(26, 'GrandfatherP2');
+      const p3 = await connectPlayer(27, 'GrandfatherP3');
+
+      const p1Started = waitForMessage(
+        p1.ws,
+        'match_started',
+        MATCH_START_TIMEOUT_MS,
+      );
+      const p2Started = waitForMessage(
+        p2.ws,
+        'match_started',
+        MATCH_START_TIMEOUT_MS,
+      );
+      const p3Started = waitForMessage(
+        p3.ws,
+        'match_started',
+        MATCH_START_TIMEOUT_MS,
+      );
+
+      await joinPlayersAndStartNow([p1, p2, p3]);
+
+      const [gs1] = await Promise.all([p1Started, p2Started, p3Started]);
+      const matchId = gs1.matchId;
+
+      // Simulate a deploy after the match started.
+      buildEnv.BUILD_HASH = 'newbuild';
+
+      // Reconnect player 1 with a stale build — should NOT get 4001 close;
+      // should replay match_started because active-match reconnect is grandfathered.
+      const wallet = createTestWallet(25);
+      const { cookie } = await createTestSession(wallet);
+      const p1r = await openWs(cookie, 'oldbuild');
+      const replayMatchStarted = await waitForMessage(
+        p1r,
+        'match_started',
+        3000,
+      );
+      expect(replayMatchStarted.matchId).toBe(matchId);
+
+      p1.ws.close();
+      p1r.close();
+      p2.ws.close();
+      p3.ws.close();
+    } finally {
+      if (previousBuildHash === undefined) {
+        delete buildEnv.BUILD_HASH;
+      } else {
+        buildEnv.BUILD_HASH = previousBuildHash;
+      }
+    }
   });
 
   it('reconnect replays player_disconnected for peers in grace period', {

--- a/test/worker/game-room.test.ts
+++ b/test/worker/game-room.test.ts
@@ -403,6 +403,17 @@ describe('GameRoom Durable Object', () => {
       const closed = await waitForClose(ws, 3000);
       expect(closed.code).toBe(4001);
     });
+
+    it('admits a matching client when BUILD_HASH carries stray whitespace', async () => {
+      buildEnv.BUILD_HASH = ` ${CURRENT_BUILD}\n`;
+      const wallet = createTestWallet(26);
+      const { accountId, cookie } = await createTestSession(wallet);
+      await seedAccount(env.DB, accountId, 'TrimmedBuildPlayer');
+      const ws = await openWs(cookie, CURRENT_BUILD);
+      const queueMsg = await waitForMessage(ws, 'queue_state', 3000);
+      expect(queueMsg.type).toBe('queue_state');
+      ws.close();
+    });
   });
 
   it('skips build-mismatch check when env.BUILD_HASH is unset', async () => {

--- a/test/worker/game-room.test.ts
+++ b/test/worker/game-room.test.ts
@@ -414,6 +414,17 @@ describe('GameRoom Durable Object', () => {
       expect(queueMsg.type).toBe('queue_state');
       ws.close();
     });
+
+    it('fails open when BUILD_HASH is not a git sha', async () => {
+      buildEnv.BUILD_HASH = 'not-a-sha';
+      const wallet = createTestWallet(27);
+      const { accountId, cookie } = await createTestSession(wallet);
+      await seedAccount(env.DB, accountId, 'TypoBuildPlayer');
+      const ws = await openWs(cookie, 'abc1234');
+      const queueMsg = await waitForMessage(ws, 'queue_state', 3000);
+      expect(queueMsg.type).toBe('queue_state');
+      ws.close();
+    });
   });
 
   it('skips build-mismatch check when env.BUILD_HASH is unset', async () => {
@@ -956,7 +967,7 @@ describe('GameRoom Durable Object', () => {
       const matchId = gs1.matchId;
 
       // Simulate a deploy after the match started.
-      buildEnv.BUILD_HASH = 'newbuild';
+      buildEnv.BUILD_HASH = 'beefca2';
 
       // Reconnect player 1 with a stale build — should NOT get 4001 close;
       // should replay match_started because active-match reconnect is grandfathered.

--- a/test/worker/http-routes.test.ts
+++ b/test/worker/http-routes.test.ts
@@ -740,10 +740,23 @@ describe('HTTP routes', () => {
       commitDuration: number;
       revealDuration: number;
       turnstileSiteKey: string | null;
+      build: string | null;
     };
     expect(data.commitDuration).toBeGreaterThan(0);
     expect(data.revealDuration).toBeGreaterThan(0);
     expect(data.turnstileSiteKey).toBe(TURNSTILE_SITE_KEY);
+    expect(data.build).toBeNull();
+  });
+
+  it('GET /api/game-config surfaces BUILD_HASH when set in env', async () => {
+    const envWithBuild = {
+      ...exampleVoteEnv,
+      BUILD_HASH: 'abc1234',
+    } satisfies Env;
+    const resp = await getWithEnv(envWithBuild, '/api/game-config');
+    expect(resp.status).toBe(200);
+    const data = (await resp.json()) as { build: string | null };
+    expect(data.build).toBe('abc1234');
   });
 
   it('POST /api/example-vote + GET /api/example-tally round-trips with a valid Turnstile token', async () => {


### PR DESCRIPTION
## Summary

Closes #251. Prevents tabs on a stale client bundle from queueing or forming matches with users on a newer deployed build, which would otherwise risk protocol drift across WebSocket message shapes, queue semantics, and UI assumptions.

- Inject the git short SHA as `BUILD_HASH` on `wrangler deploy` (single source of truth, same value as the HTML stamp).
- Expose it on `/api/game-config` as `build` and have the browser send it on `/ws` as `?clientBuild=<sha>`.
- Enforce at the DO queue/forming boundary only — active-match reconnects are grandfathered (all players in a live match share a build), so in-progress matches finish uninterrupted across deploys.
- On mismatch, close with dedicated code `4001 / 'client build mismatch'`. The frontend latches a terminal stale-build state on 4001: all reconnect paths (retry scheduler, visibilitychange, online, identity refresh, queue actions) no-op until the page is refreshed, and a persistent "new version — refresh" banner is shown. Terminal banners update in place, so the newest terminal state (tab replacement vs. build mismatch) always wins.
- `BUILD_HASH` is trimmed at both read sites (admission gate, `/api/game-config`) and validated against the same sha regex as the client value at the gate, so stray whitespace or a mistyped `--var` from a manual deploy cannot fail closed and reject every client.
- When `BUILD_HASH` is unset the gate fails open by design (rejecting everyone on a missing var would take queueing down entirely; unset is the expected state under `wrangler dev`), and the DO logs a one-time warning so a manual deploy that forgot `--var` is visible.
- Defensive: length cap (≤64 chars) in the HTTP handler + regex validation (`/^[a-f0-9]{7,40}$/`) in the DO, which is the single authoritative enforcement point. `clientBuild` is treated as a UX hint, not an auth boundary.

## Review feedback addressed

Owner review (bdd1be8):
- One-time `console.warn` when the admission gate is disabled because `BUILD_HASH` is unset.
- Dropped the write-only `ConnectionState.clientBuild` field (enforcement reads the URL param at admission time; the stored copy had no reader).
- `showTerminalClose` now overwrites the existing banner text instead of returning early, so an earlier tab-replacement banner no longer suppresses a later build-mismatch message.

Copilot review (a3c205d):
- Trim `BUILD_HASH` once at each read site; new worker test pins the trim contract (whitespace-padded `BUILD_HASH` still admits a matching client).
- `buildMismatchTerminal` latch on the client: `connectWebSocket` no-ops while latched, closing the reconnect loopholes through `resumeWebSocketReconnect` / `ensureWebSocketConnection` / `refreshLiveWebSocketIdentity` that reset `intentionalClose`. Queue actions re-surface the refresh banner instead of a misleading "sign in again" toast.

Copilot review round 2 (ed7de96):
- Validate the deployed `BUILD_HASH` against the sha regex (`BUILD_HASH_RE`, renamed from `CLIENT_BUILD_HASH_RE` since it now guards both sides); a non-hex value disables the gate with the one-time warning instead of rejecting every client. New worker test pins fail-open on a malformed `BUILD_HASH`; the grandfather test's simulated deploy hash switched to valid hex so it keeps exercising the gate.

Copilot review round 3 (02135ce):
- Smoke build assertions now require the sha shape the gate enforces (was: any non-empty string), so a misconfigured `BUILD_HASH` that silently disables the fail-open gate fails the deploy instead.
- Gate warning says "git sha" instead of "git short sha" (the regex accepts short or full length).

## Deploy note

One-time churn on the first deploy after merge: currently-open tabs on pre-PR cached bundles have no `4001` handler, so their old `onclose` falls through to the reconnect scheduler and they close/retry until refreshed. The DO closes pre-state so the cost per attempt is low, and the behavior self-extinguishes once post-PR bundles are cached.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run typecheck:worker`
- [x] `npm test` — 121/121 domain tests
- [x] `npm run test:worker` — 179/180 worker tests (1 pre-existing extended-lifecycle test behind `RUN_EXTENDED_WORKER_TESTS` is skipped)
- [x] New coverage: `/api/game-config` exposes `build` (null when unset, value when set); `/ws` with matching / mismatched / malformed / missing `clientBuild`; whitespace-padded `BUILD_HASH` admits a matching client; malformed `BUILD_HASH` fails open; mid-match reconnect with a stale build stays grandfathered.
- [x] All suites re-run green after each review-feedback commit.
- [ ] Manual: deploy to staging and confirm stale-tab queue join closes with the refresh banner while a mid-match tab finishes settlement unaffected.
